### PR TITLE
Feature/feature/bu banners has page title

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,287 +1,293 @@
 # Changelog
 
+# Unreleased
+
+-   Added new template tag, `responsive_the_title()`, intended to output the page title for each single post/page template.
+-   Added new filter to the new `responsive_the_title()` template_tag, named `responsive_filter_page_title` which can be used to
+    modify/prevent the output of page titles in responsive-framework.
+
 # 2.1.3
 
-- Added BU Hub Indicator. Incorporated adjustments to line height.
+-   Added BU Hub Indicator. Incorporated adjustments to line height.
 
 # 2.1.2
 
-- Move 2.1.2 to a new repo for a fresh start in prepartion to begin the open source process.
+-   Move 2.1.2 to a new repo for a fresh start in prepartion to begin the open source process.
 
-## Unreleased
+# 2.0.0
 
-- Added CONTRIBUTING.md file for contribution rules.
-- Removed use of `file_get_contents()` in the Customizer.
-- Responsive Framework "header" templates are now renamed to "masthead"
- templates to avoid confusion with WordPress core's header template
- functionality.
-- Page templates have been updated to be more simple. A template part should be
- a repeatable chunk that can be used within the loop. All logic determining
- what should show, how, or where, should be contained in the page template.
-- For most post types, single templates only display content in one way. For
- that reason, single templates should not use `get_template_part()` unless more
- than one display variations actually exist.
-- Updated profile, news, and page templates to use the above thought process.
-- `responsive_post_lists_show_news_meta()` no longer requires a settings array
- to be passed when called. By default, it will utilize the settings selected on
- the news page. An array of settings different form those selected can still be
- passed.
-- Introduce several action hooks to make it easier for child themes to inject
- markup without having to copy the entire template file. Hooks introduced:
-  - `r_after_opening_body_tag`
-  - `r_before_opening_wrapper`
-  - `r_after_opening_wrapper`
-  - `r_before_opening_container_outer`
-  - `r_after_opening_container_outer`
-  - `r_before_opening_container_inner`
-  - `r_after_opening_container_inner`
-  - `r_before_masthead`
-  - `r_after_masthead`
-  - `r_before_closing_container_inner`
-  - `r_after_closing_container_inner`
-  - `r_before_closing_container_outer`
-  - `r_after_closing_container_outer`
-  - `r_before_closing_wrapper`
-  - `r_after_closing_wrapper`
-  - `r_before_branding_masterplate`
-  - `r_after_branding_masterplate`
-  - `r_before_bumc_branding_logo`
-  - `r_after_bumc_branding_logo`
-  - `r_before_branding_disclaimer`
-  - `r_after_branding_disclaimer`
-  - ~~`r_before_content_banner_{position}`~~
-  - ~~`r_before_content_banner`~~
-  - ~~`r_after_content_banner_{position}`~~
-  - ~~`r_after_content_banner`~~
-- ~~Added `r_content_banner_args` filter for modifying generated content banner
- arguments.~~
-- ~~Added `r_content_banner_output` filter for modifying content banner output.
- This was previously `responsive_content_banner_output`.~~
-- Add `branding.php` template part so child themes can override the default
- branding markup by calling `remove_theme_support( 'bu-branding' )`.
-- Add `r_script_in_footer` filter for changing the loading location of the
- theme's JavaScript file.
-- Add `r_enqueue_modernizr` filter for preventing Modernizr from being
- enqueued. Child themes and plugins can use this to load their own build of
- Modernizr.
-- Add video autoplay to the list of Modernizr checks.
-- Introduce `r_get_template_part()`. Adds the ability to theme a specific post
- type's display in archive contexts within a child theme without having to
- change the `archive.php` template that serves as the default for all archive
- pages. For more details see [102e38a](https://github.com/bu-ist/responsive-framework/pull/153/commits/102e38aa79a6d42bd782d5d4be5c1d3f20fc5b83).
-- Introduce `r_get_archive_sidebar()`. Adds the ability to theme sidebars for
- specific archive contexts without having to change the `archive.php` template
- in a child theme. For more details see [55f3602](https://github.com/bu-ist/responsive-framework/pull/153/commits/55f3602dc496439d414f28a24b72dd6e19edec99).
-- Update `responsive_term_links()` to act as a wrapper of `get_the_term_list()`
- to solve several issues. See [#185](https://github.com/bu-ist/responsive-framework/issues/185).
-- Set up unit testing with Travis CI with an initial test suite. These should be
- updated and maintained with every pull request.
-- Set up Code Climate test coverage reporting.
-- Make sure `post_class()` is used for every container of every post,
- regardless of post type.
-- Comment message field is now marked required. The browser will now notify the
- commenter when they try to submit the form if the field is empty.
-- Ensure `role="main"` is used properly and adheres to the proper accessibility
- standards.
-- Add HTML5 required attributes to comment form elements and require comments.
-- Fixes a longstanding issue with the left navigation layout where pages with
- little to no content would cut off the navigation.
-- Remove unnecessary gravatars markup.
-- Clarifies the use of Footer Additional Information in the Customizer.
-- Adds a new class, `content-area`, for styling what was formerly
- `article[role=main]`.
-- Moves `profiles.php` to the root of the theme directory from `/page-templates`
- to allow users to select which profile format to use on the profiles template.
-- Introduce `r_container_inner_class()` for displaying the class attribute for
- the inner content container element. Classes are filterable through the
- `r_container_inner_class` filter.
-- Introduce `r_container_outer_class()` for displaying the class attribute for
- the outer content container element. Classes are filterable through the
- `r_container_outer_class` filter.
-- Fetch the `.mdlrc` and `markdown.rb` files from the [coding standards repository](https://github.com/bu-ist/coding-standards/tree/master).
-- Restructured HTML and added CSS classes in the footer for cleaner branding
- styles.
-- Add extra classes to `post_class()` based on template part and template type.
-- Introduces unique classes to output HTML based on content type and scope of
- styles. For example, a title on the new calendar widget classes using the graphic
- format will have both `.widget-calendar-title` and `.widget-calendar-title-graphic`,
- which makes it clearer exactly which content is affected when overriding a class.
-- Smarter use of CSS inheritance in the fonts and color palette CSS generated byline
- Customizer.
-- Introduces a class for the first calendar event at a time in a long list of times.
-- Cleans up unnecessary wrapper HTML from Flexi Framework.
-- Major improvements to the default course feeds template, which now link to
- building location, show course instructors, fix the broken course type and display
- as a whole word instead of an abbreviation, display semester availability,
- display prerequisites for the course, and removes the cryptic course ID in favor
- of a clearer display of section ID, semester, and year.
-- Adds unique callbacks for calendar widget formats and updates tags to HTML5.
-- Adds a lightbox for galleries automatically.
-- Add a page template dropdown filter to the top of the page admin screen.
-- Switches `content-container` class to a plain div inside of `main`, which enables
- you to use this class as many times as you need to, such as in a landing page.
-- UI improvements: "Layout" is now called "Navigation Style" in Customizer to
- avoid future conflicts with a potential layout builder and clarify functionality.
-- Underscores are no longer stripped from classes in HTML.
-- Title attributes have been removed from anchor tags to promote accessibility.
-- Upgrade Modernizr and add new tests: sticky, video autoplay.
-- Deactivate the BU Mobile plugin when the theme is activated.
-- Introduce pull request and issue templates.
-- Add `<picture>` element support detection to Modernizr.
-- Prepare the theme for localization using internationalization best practices.
-- Remove `bu_search_form_query_attributes` filter function. This is now the
- default behavior in BU-CMS.
-- Remove Content Banner support.
-- Add Grunt time reporting.
-- Rename `content-none.php` to `no-content.php`.
+-   Added CONTRIBUTING.md file for contribution rules.
+-   Removed use of `file_get_contents()` in the Customizer.
+-   Responsive Framework "header" templates are now renamed to "masthead"
+    templates to avoid confusion with WordPress core's header template
+    functionality.
+-   Page templates have been updated to be more simple. A template part should be
+    a repeatable chunk that can be used within the loop. All logic determining
+    what should show, how, or where, should be contained in the page template.
+-   For most post types, single templates only display content in one way. For
+    that reason, single templates should not use `get_template_part()` unless more
+    than one display variations actually exist.
+-   Updated profile, news, and page templates to use the above thought process.
+-   `responsive_post_lists_show_news_meta()` no longer requires a settings array
+    to be passed when called. By default, it will utilize the settings selected on
+    the news page. An array of settings different form those selected can still be
+    passed.
+-   Introduce several action hooks to make it easier for child themes to inject
+    markup without having to copy the entire template file. Hooks introduced:
+    -   `r_after_opening_body_tag`
+    -   `r_before_opening_wrapper`
+    -   `r_after_opening_wrapper`
+    -   `r_before_opening_container_outer`
+    -   `r_after_opening_container_outer`
+    -   `r_before_opening_container_inner`
+    -   `r_after_opening_container_inner`
+    -   `r_before_masthead`
+    -   `r_after_masthead`
+    -   `r_before_closing_container_inner`
+    -   `r_after_closing_container_inner`
+    -   `r_before_closing_container_outer`
+    -   `r_after_closing_container_outer`
+    -   `r_before_closing_wrapper`
+    -   `r_after_closing_wrapper`
+    -   `r_before_branding_masterplate`
+    -   `r_after_branding_masterplate`
+    -   `r_before_bumc_branding_logo`
+    -   `r_after_bumc_branding_logo`
+    -   `r_before_branding_disclaimer`
+    -   `r_after_branding_disclaimer`
+    -   ~~`r_before_content_banner_{position}`~~
+    -   ~~`r_before_content_banner`~~
+    -   ~~`r_after_content_banner_{position}`~~
+    -   ~~`r_after_content_banner`~~
+-   ~~Added `r_content_banner_args` filter for modifying generated content banner
+    arguments.~~
+-   ~~Added `r_content_banner_output` filter for modifying content banner output.
+    This was previously `responsive_content_banner_output`.~~
+-   Add `branding.php` template part so child themes can override the default
+    branding markup by calling `remove_theme_support( 'bu-branding' )`.
+-   Add `r_script_in_footer` filter for changing the loading location of the
+    theme's JavaScript file.
+-   Add `r_enqueue_modernizr` filter for preventing Modernizr from being
+    enqueued. Child themes and plugins can use this to load their own build of
+    Modernizr.
+-   Add video autoplay to the list of Modernizr checks.
+-   Introduce `r_get_template_part()`. Adds the ability to theme a specific post
+    type's display in archive contexts within a child theme without having to
+    change the `archive.php` template that serves as the default for all archive
+    pages. For more details see [102e38a](https://github.com/bu-ist/responsive-framework/pull/153/commits/102e38aa79a6d42bd782d5d4be5c1d3f20fc5b83).
+-   Introduce `r_get_archive_sidebar()`. Adds the ability to theme sidebars for
+    specific archive contexts without having to change the `archive.php` template
+    in a child theme. For more details see [55f3602](https://github.com/bu-ist/responsive-framework/pull/153/commits/55f3602dc496439d414f28a24b72dd6e19edec99).
+-   Update `responsive_term_links()` to act as a wrapper of `get_the_term_list()`
+    to solve several issues. See [#185](https://github.com/bu-ist/responsive-framework/issues/185).
+-   Set up unit testing with Travis CI with an initial test suite. These should be
+    updated and maintained with every pull request.
+-   Set up Code Climate test coverage reporting.
+-   Make sure `post_class()` is used for every container of every post,
+    regardless of post type.
+-   Comment message field is now marked required. The browser will now notify the
+    commenter when they try to submit the form if the field is empty.
+-   Ensure `role="main"` is used properly and adheres to the proper accessibility
+    standards.
+-   Add HTML5 required attributes to comment form elements and require comments.
+-   Fixes a longstanding issue with the left navigation layout where pages with
+    little to no content would cut off the navigation.
+-   Remove unnecessary gravatars markup.
+-   Clarifies the use of Footer Additional Information in the Customizer.
+-   Adds a new class, `content-area`, for styling what was formerly
+    `article[role=main]`.
+-   Moves `profiles.php` to the root of the theme directory from `/page-templates`
+    to allow users to select which profile format to use on the profiles template.
+-   Introduce `r_container_inner_class()` for displaying the class attribute for
+    the inner content container element. Classes are filterable through the
+    `r_container_inner_class` filter.
+-   Introduce `r_container_outer_class()` for displaying the class attribute for
+    the outer content container element. Classes are filterable through the
+    `r_container_outer_class` filter.
+-   Fetch the `.mdlrc` and `markdown.rb` files from the [coding standards repository](https://github.com/bu-ist/coding-standards/tree/master).
+-   Restructured HTML and added CSS classes in the footer for cleaner branding
+    styles.
+-   Add extra classes to `post_class()` based on template part and template type.
+-   Introduces unique classes to output HTML based on content type and scope of
+    styles. For example, a title on the new calendar widget classes using the graphic
+    format will have both `.widget-calendar-title` and `.widget-calendar-title-graphic`,
+    which makes it clearer exactly which content is affected when overriding a class.
+-   Smarter use of CSS inheritance in the fonts and color palette CSS generated byline
+    Customizer.
+-   Introduces a class for the first calendar event at a time in a long list of times.
+-   Cleans up unnecessary wrapper HTML from Flexi Framework.
+-   Major improvements to the default course feeds template, which now link to
+    building location, show course instructors, fix the broken course type and display
+    as a whole word instead of an abbreviation, display semester availability,
+    display prerequisites for the course, and removes the cryptic course ID in favor
+    of a clearer display of section ID, semester, and year.
+-   Adds unique callbacks for calendar widget formats and updates tags to HTML5.
+-   Adds a lightbox for galleries automatically.
+-   Add a page template dropdown filter to the top of the page admin screen.
+-   Switches `content-container` class to a plain div inside of `main`, which enables
+    you to use this class as many times as you need to, such as in a landing page.
+-   UI improvements: "Layout" is now called "Navigation Style" in Customizer to
+    avoid future conflicts with a potential layout builder and clarify functionality.
+-   Underscores are no longer stripped from classes in HTML.
+-   Title attributes have been removed from anchor tags to promote accessibility.
+-   Upgrade Modernizr and add new tests: sticky, video autoplay.
+-   Deactivate the BU Mobile plugin when the theme is activated.
+-   Introduce pull request and issue templates.
+-   Add `<picture>` element support detection to Modernizr.
+-   Prepare the theme for localization using internationalization best practices.
+-   Remove `bu_search_form_query_attributes` filter function. This is now the
+    default behavior in BU-CMS.
+-   Remove Content Banner support.
+-   Add Grunt time reporting.
+-   Rename `content-none.php` to `no-content.php`.
 
 ## 1.5.6
 
-- Remove empty IE conditional at the beginning of `header.php` ([#272](https://github.com/bu-ist/responsive-framework/issues/272)).
-- Ensure the correct default value is returned for
- `BU_RESPONSIVE_POSTS_SIDEBAR_SHOW_BOTTOM` ([#268](https://github.com/bu-ist/responsive-framework/pull/268)).
+-   Remove empty IE conditional at the beginning of `header.php` ([#272](https://github.com/bu-ist/responsive-framework/issues/272)).
+-   Ensure the correct default value is returned for
+    `BU_RESPONSIVE_POSTS_SIDEBAR_SHOW_BOTTOM` ([#268](https://github.com/bu-ist/responsive-framework/pull/268)).
 
 ## 1.5.5
 
-- Fix bug where nav toggle icon was not receiving the correct color (#251).
+-   Fix bug where nav toggle icon was not receiving the correct color (#251).
 
 ## 1.5.4
 
-* Enables pinch to zoom for accessibility on mobile.
-* Fixes a bug where BUMC branding styles do not apply correctly.
-* Add `right` default to `burf_setting_sidebar_location` option.
+-   Enables pinch to zoom for accessibility on mobile.
+-   Fixes a bug where BUMC branding styles do not apply correctly.
+-   Add `right` default to `burf_setting_sidebar_location` option.
 
 ## 1.5.3
 
-- Move the body `id` declaration in front of `class`.
+-   Move the body `id` declaration in front of `class`.
 
 ## 1.5.2
 
-- Fix `responsive_maybe_hide_homepage_h1()` to accept the second parameter for
- `the_title` filter.
-- Introduce the `r_script_dependencies` filter. Used to filter script
- dependencies for child theme script files.
+-   Fix `responsive_maybe_hide_homepage_h1()` to accept the second parameter for
+    `the_title` filter.
+-   Introduce the `r_script_dependencies` filter. Used to filter script
+    dependencies for child theme script files.
 
 ## 1.4.3
 
-- Fix for BUniverse embeds/shortcode to support HTTPS.
+-   Fix for BUniverse embeds/shortcode to support HTTPS.
 
 ## 1.4.2
 
-- Updating to newest tag (1.3.2) of Responsive Foundation
+-   Updating to newest tag (1.3.2) of Responsive Foundation
 
 ## 1.4.1
 
-- Updating to newest tag (1.3.0) of Responsive Foundation
+-   Updating to newest tag (1.3.0) of Responsive Foundation
 
 ## 1.4.0
 
-- Calendar api update: enabling monthly dropdown menu & topic heading text
-- Search form & search form accessibility improvements
-- Branding updates
-- Customizer Layout & Fonts bug fix (#43)
+-   Calendar api update: enabling monthly dropdown menu & topic heading text
+-   Search form & search form accessibility improvements
+-   Branding updates
+-   Customizer Layout & Fonts bug fix (#43)
 
 ## 1.3.5
 
-- Fixing post display options array [Commit](https://github.com/bu-ist/responsive-framework/commit/dd72447ea1e54b5ee7ba572a00b82d4c1691321e)
-- Update to [Responsive Foundation 1.2.1](https://github.com/bu-ist/responsive-foundation/releases/tag/1.2.1)
+-   Fixing post display options array [Commit](https://github.com/bu-ist/responsive-framework/commit/dd72447ea1e54b5ee7ba572a00b82d4c1691321e)
+-   Update to [Responsive Foundation 1.2.1](https://github.com/bu-ist/responsive-foundation/releases/tag/1.2.1)
 
 ## 1.3.4-beta
 
-- Create new gravity forms contact forms only when necessary.
-  - They should be generated only when current site has contact forms using the
-   Contact Us plugin.
-  - Previous bug: gravity forms were generated for sites without contact forms.
-   And if the theme got activated multiple times, more gravity forms were
-   generated each time.
+-   Create new gravity forms contact forms only when necessary.
+    -   They should be generated only when current site has contact forms using the
+        Contact Us plugin.
+    -   Previous bug: gravity forms were generated for sites without contact forms.
+        And if the theme got activated multiple times, more gravity forms were
+        generated each time.
 
 ## 1.3.3-beta
 
-- Updating to Responsive Foundation 1.2.0 (Bunnies)
+-   Updating to Responsive Foundation 1.2.0 (Bunnies)
 
 ## 1.3.2-beta
 
-- Add filter to responsive_content_banner to manipulate output on theme level
+-   Add filter to responsive_content_banner to manipulate output on theme level
 
 ## 1.3.1-beta
 
-- Add `no-access.php` and no-access-bumc.php` template files to framework for
- Audience plugin on bumc.bu.edu
+-   Add `no-access.php` and no-access-bumc.php` template files to framework for
+    Audience plugin on bumc.bu.edu
 
 ## 1.3.0-beta
 
-- Responsi-as-a-Service beta release
-- Enable Customizer font palettes for non-child themes
-- Enable Customizer color palettes for non-child themes
-- Add Customizer display options for toggling visibility of post meta fields
-- Add Customizer sidebar options for toggling usage of alternate footbars
-- Update footer branding styles to support BUMC logo, disclaimer link
-- Update site initialization / automated Flexi migration logic
+-   Responsi-as-a-Service beta release
+-   Enable Customizer font palettes for non-child themes
+-   Enable Customizer color palettes for non-child themes
+-   Add Customizer display options for toggling visibility of post meta fields
+-   Add Customizer sidebar options for toggling usage of alternate footbars
+-   Update footer branding styles to support BUMC logo, disclaimer link
+-   Update site initialization / automated Flexi migration logic
 
 ## 1.2.2
 
-- Add fallback for branding
+-   Add fallback for branding
 
 ## 1.2.1
 
-- Change empty value for calendar event time from '&nbsp;' to ''
-- Add site initialization and Flexi migration logic (dormant pending release of
- Site Manager 4.0.0)
-- Fix #30: Don't display search icon when search is disabled
-- Fix #32: Don't override threaded comment depth set via Settings > Discussion
-- Fix #19: Update social media icons to add alternate icons, fix issues with
- Flickr / Vine and Google+. See [a304709](https://github.com/bu-ist/responsive-foundation/commit/a30470947bc5bf05533e183e31f2060dd89d99c2).
-- Fix typo with archive button.
+-   Change empty value for calendar event time from '&nbsp;' to ''
+-   Add site initialization and Flexi migration logic (dormant pending release of
+    Site Manager 4.0.0)
+-   Fix #30: Don't display search icon when search is disabled
+-   Fix #32: Don't override threaded comment depth set via Settings > Discussion
+-   Fix #19: Update social media icons to add alternate icons, fix issues with
+    Flickr / Vine and Google+. See [a304709](https://github.com/bu-ist/responsive-foundation/commit/a30470947bc5bf05533e183e31f2060dd89d99c2).
+-   Fix typo with archive button.
 
 ## 1.2.0
 
-- Add support for BU Branding plugin
-- Add template tags for display of BUMC logo and disclaimer
-- Add support for BU Sharing plugin
-- Introduce `responsive_share_tools()` for share tools display
-- Ensure Customizer is accessible to non-super admin
-- Remove shims for BU Profiles / Content Banner template tags that have been
- integrated into plugins
-- Add hooks to upgrade function to support pending migration of Research theme
+-   Add support for BU Branding plugin
+-   Add template tags for display of BUMC logo and disclaimer
+-   Add support for BU Sharing plugin
+-   Introduce `responsive_share_tools()` for share tools display
+-   Ensure Customizer is accessible to non-super admin
+-   Remove shims for BU Profiles / Content Banner template tags that have been
+    integrated into plugins
+-   Add hooks to upgrade function to support pending migration of Research theme
 
 ## 1.1.0
 
-- Add basic BUniverse embed provider
-- Archive template now utilizes profile template parts for profile-specific
- taxonomy archives (#22)
-- Profile shortcode templates now utilize template partials
-- Navigation template tags now support customizable labels and screen reader
- text (#23)
-- Navigation template tags are now post type-agnostic
-- Fix posts navigation button placement (they were reversed)
-- Fix #18: Empty <p> tags when no post meta exists for News template
-- Fix #21: Use correct class attribute for `[buniverse]` shortcode
-- Introduce `responsive_archive_type()` and `responsive_queried_post_types()`
- helpers (#22)
-- Deprecate `responsive_paging_nav()` in favor of
- `responsive_posts_navigation()`
-- Deprecate `responsive_post_nav()` in favor of `responsive_post_navigation()`
+-   Add basic BUniverse embed provider
+-   Archive template now utilizes profile template parts for profile-specific
+    taxonomy archives (#22)
+-   Profile shortcode templates now utilize template partials
+-   Navigation template tags now support customizable labels and screen reader
+    text (#23)
+-   Navigation template tags are now post type-agnostic
+-   Fix posts navigation button placement (they were reversed)
+-   Fix #18: Empty <p> tags when no post meta exists for News template
+-   Fix #21: Use correct class attribute for `[buniverse]` shortcode
+-   Introduce `responsive_archive_type()` and `responsive_queried_post_types()`
+    helpers (#22)
+-   Deprecate `responsive_paging_nav()` in favor of
+    `responsive_posts_navigation()`
+-   Deprecate `responsive_post_nav()` in favor of `responsive_post_navigation()`
 
 ## 1.0.3
 
-- Update to [Responsive Foundation 1.0.3](https://github.com/bu-ist/responsive-foundation/releases/tag/1.0.3)
+-   Update to [Responsive Foundation 1.0.3](https://github.com/bu-ist/responsive-foundation/releases/tag/1.0.3)
 
 ## 1.0.2
 
-- Add href to BU masterplate
+-   Add href to BU masterplate
 
 ## 1.0.1
 
-- Add shortcode parsing for core text widgets
-- Fix footbar position in sideNav layout
-- Refactored header markup
+-   Add shortcode parsing for core text widgets
+-   Fix footbar position in sideNav layout
+-   Refactored header markup
 
 ## 1.0.0
 
-- Deemed stable for child theme development
+-   Deemed stable for child theme development
 
 ## 0.9.1
 
-- Pre-release version of Responsi.
-- Child themes based on 0.9.1 include: r-cfa, r-hr, r-pardeeschool, r-research,
- and r-school.
+-   Pre-release version of Responsi.
+-   Child themes based on 0.9.1 include: r-cfa, r-hr, r-pardeeschool, r-research,
+    and r-school.

--- a/home.php
+++ b/home.php
@@ -11,9 +11,12 @@ $page_for_posts = get_option( 'page_for_posts', 0 );
 ?>
 
 <article class="content-area">
-	<?php if ( ! is_front_page() && is_home() && ! empty( $page_for_posts ) ) : ?>
-		<h1 <?php r_page_title_class( '', true ); ?>><?php echo get_the_title( $page_for_posts ); ?></h1>
-	<?php endif; ?>
+	<?php
+	// Output the posts page's title if this is a blog listings page.
+	if ( ! is_front_page() && is_home() && ! empty( $page_for_posts ) ) {
+		responsive_the_title( '<h1 ' . r_page_title_class( '', true ) . '>', '</h1>', true, $page_for_posts );
+	}
+	?>
 
 	<?php if ( have_posts() ) : ?>
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -6,7 +6,7 @@
  */
 
 /**
- * Print the site's title.
+ * Print the site's title tag for `<head />` element.
  */
 function responsive_get_title() {
 	global $page, $paged;

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -24,6 +24,54 @@ function responsive_get_title() {
 }
 
 /**
+ * Displays the current page title.
+ *
+ * Functions like `the_title()`, but can be filtered to prevent or change the output
+ * intended for the main page title. Accepts the same arguments as `the_title()`, with
+ * an additional argument for $post->ID.
+ *
+ * Note: Intended only to be used where the main page title is.
+ *       Not intended to be used for things like a listing of posts.
+ *
+ * @since    2.1.4
+ *
+ * @link     https://codex.wordpress.org/Function_Reference/the_title
+ * @link     https://developer.wordpress.org/reference/hooks/the_title/
+ *
+ * @param    string $before Text to insert before the title, such as an opening h1 tag.
+ * @param    string $after  Text to insert after the title, such as a closing h1 tag.
+ * @param    bool   $echo   Prints the title to the screen when called. Defaults to true.
+ * @param    int    $id     Retrieves the title for a given post id.
+ */
+function responsive_the_title( $before = '', $after = '', $echo = true, $id = false ) {
+
+	/**
+	 * Filters the current page title.
+	 *
+	 * Useful for when something besides `get_the_title()` for the current query
+	 * should be used.
+	 *
+	 * @since    2.1.4
+	 */
+	$title = apply_filters( 'responsive_filter_page_title', get_the_title( $id ) );
+
+	// Only continues if a title exists and wasn't removed by the filter.
+	if ( ! empty( $title ) ) {
+
+		// Apply the normal `the_title` filters.
+		$title = apply_filters( 'the_title', $before . $title . $after );
+
+		// Echoes or returns the title.
+		if ( $echo ) {
+			// Only allows html that can be used inside `the_content`.
+			echo wp_kses_post( $title );
+		} else {
+			return $title;
+		}
+	}
+}
+
+/**
  * Whether or not the current network is a bu.edu domain.
  *
  * @return bool true if the blog is a BU domain, false if it is not or returns

--- a/page-templates/calendar.php
+++ b/page-templates/calendar.php
@@ -86,7 +86,7 @@ if ( is_null( $eventID ) ) {
 
 		<?php if ( is_null( $eventID ) ) { ?>
 			<?php if ( have_posts() ) : while ( have_posts() ) : the_post(); ?>
-				<?php the_title( '<h1 ' . r_page_title_class() . '>', '</h1>' ); ?>
+				<?php responsive_the_title( '<h1 ' . r_page_title_class() . '>', '</h1>' ); ?>
 				<?php the_content( '<p class="serif">Read the rest of this page &raquo;</p>' ); ?>
 
 				<?php wp_link_pages( array( 'before' => '<p><strong>Pages:</strong> ', 'after' => '</p>', 'next_or_number' => 'number' ) ); ?>

--- a/page-templates/news.php
+++ b/page-templates/news.php
@@ -20,7 +20,7 @@ get_header();
 
 	<article id="post-<?php the_ID(); ?>" <?php post_class( 'content-area' ); ?>>
 
-		<?php the_title( '<h1 ' . r_page_title_class() . '>', '</h1>' ); ?>
+		<?php responsive_the_title( '<h1 ' . r_page_title_class() . '>', '</h1>' ); ?>
 
 		<?php the_content(); ?>
 

--- a/page-templates/no-sidebars.php
+++ b/page-templates/no-sidebars.php
@@ -11,7 +11,7 @@ get_header();
 	<?php while ( have_posts() ) : the_post(); ?>
 
 		<article id="post-<?php the_ID(); ?>" <?php post_class( 'content-area' ); ?>>
-			<?php the_title( '<h1 ' . r_page_title_class() . '>', '</h1>' ); ?>
+			<?php responsive_the_title( '<h1 ' . r_page_title_class() . '>', '</h1>' ); ?>
 
 			<?php the_content(); ?>
 

--- a/page.php
+++ b/page.php
@@ -15,7 +15,7 @@ get_header();
 
 		<article id="post-<?php the_ID(); ?>" <?php post_class( 'content-area' ); ?>>
 
-			<?php the_title( '<h1 ' . r_page_title_class() . '>', '</h1>' ); ?>
+			<?php responsive_the_title( '<h1 ' . r_page_title_class() . '>', '</h1>' ); ?>
 
 			<?php the_content(); ?>
 

--- a/profiles.php
+++ b/profiles.php
@@ -11,7 +11,7 @@ get_header(); ?>
 
 		<article id="post-<?php the_ID(); ?>" class="content-area">
 
-			<?php the_title( '<h1 ' . r_page_title_class() . '>', '</h1>' ); ?>
+			<?php responsive_the_title( '<h1 ' . r_page_title_class() . '>', '</h1>' ); ?>
 
 			<?php the_content( '<p class="serif">' . esc_html__( 'Read the rest of this profile &raquo;', 'responsive-framework' ) . '</p>' ); ?>
 

--- a/single.php
+++ b/single.php
@@ -11,7 +11,7 @@ get_header(); ?>
 
 		<article id="post-<?php the_ID(); ?>" <?php post_class( 'content-area' ); ?>>
 
-			<?php the_title( '<header><h1 ' . r_page_title_class() . '>', '</h1></header>' ); ?>
+			<?php responsive_the_title( '<header><h1 ' . r_page_title_class() . '>', '</h1></header>' ); ?>
 
 
 			<?php the_content(); ?>


### PR DESCRIPTION
Fixes issue where BU Banners plugin needs to output the page title, and not have it duplicated by responsive-framework. This new function is intended only to be used once on each page template for outputting the main page title, and has a filter that can be hooked into to change/prevent the output. Functions the same way as the_title(). This resolves the issue where bu banners used `the_title` filter to prevent output and had negative impacts on other functions trying to output page titles such as nav menu widgets.

### Changes proposed in this pull request
- Adds a new `responsive_the_title()` function intended to be output for the page/post title.
- Changes instances where `the_title()` function was being used for templates, and replaces them with `responsive_the_title()`
- The new `responsive_the_title()` function has a filter to prevent responsive-framework from outputting anything, via `responsive_filter_page_title()`.

### Required pull requests to merge (usually a pull request on Foundation or a plugin)
- BU Banners https://github.com/bu-ist/bu-banners/pull/156 will need to get merged for the plugin to properly prevent page title output.

### Review checklist
[x] I've reviewed the [contribution guidelines](https://github.com/bu-ist/coding-standards/blob/develop/CONTRIBUTING.md).
[x] I've updated `CHANGELOG.MD` with a brief explanation of the main changes in this pull request.
[x] My code follows [BU Coding Standards](https://github.com/bu-ist/coding-standards).
