### PR TITLE
Bypass empty BU Text widgets in class count increment via filter

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -705,6 +705,43 @@ function r_enqueue_fancy_gallery() {
 }
 
 /**
+ * Filter used to prevent incrementing CSS widget class count if a BU Text Widget is empty.
+ *
+ * @since 2.1.9
+ *
+ * @param bool  $is_widget_empty Defaults to false, assumes widget has content.
+ * @param array $params An array of Widget options info.
+ *
+ * @return bool $is_widget_empty The status of content for the widget.
+ */
+function r_is_bu_text_widget_empty( $is_widget_empty, $params ) {
+	$widget_name = $params[0]['widget_name'];
+
+	if ( 'BU Text' === $widget_name ) {
+		$widget_instance = $params[1]['number'];
+		$meta_key        = '_bu_text_widget_' . $widget_instance;
+		$widget_meta     = get_post_meta( get_the_ID(), $meta_key, true );
+
+		if ( empty( $widget_meta['content'] ) ) {
+			$is_widget_empty = true;
+		}
+	}
+	return $is_widget_empty;
+}
+
+/**
+ * Adds the empty widget check filter if the BU Text Widget plugin is active.
+ *
+ * @since 2.1.9
+ */
+function r_bu_text_widget_loaded() {
+	if ( is_plugin_active( 'bu-text-widget/bu-text-widget.php' ) ) {
+		add_filter( 'responsive_is_widget_empty', 'r_is_bu_text_widget_empty', 10, 2 );
+	}
+}
+add_action( 'after_setup_theme', 'r_bu_text_widget_loaded' );
+
+/**
  * Remove the news template when BU_News_Page_Template does not exist.
  *
  * @param string[]     $templates Array of page templates. Keys are filenames,

--- a/inc/extras.php
+++ b/inc/extras.php
@@ -166,6 +166,22 @@ function responsive_widget_counts( $params ) {
 		return $params;
 	}
 
+	/**
+	 * Filters the $is_widget_empty variable.
+	 *
+	 * @since 2.1.9
+	 *
+	 * @params bool $is_widget_empty The empty/full status of the widget content.
+	 *
+	 * @params array $params An array of widget options.
+	 */
+	$is_widget_empty = apply_filters( 'responsive_is_widget_empty', $is_widget_empty = false, $params );
+
+	// Don't increment static widget counter if widget is empty because it will not be displayed.
+	if ( $is_widget_empty ) {
+		return $params;
+	}
+
 	// Initialize or increment our static widget counter by one for this widget.
 	if ( array_key_exists( $current_sidebar, $widget_counter ) ) {
 		$widget_counter[ $current_sidebar ] ++;


### PR DESCRIPTION
Fixes #45 

### Changes proposed in this pull request

- Create filter `responsive_is_widget_empty` to help check for empty widgets.
- Add filter to check for empty BU Text widgets.
- Make filter fire only if BU Text Widget is active keeping in mind goal of open sourcing this theme and general performance.
- This will prevent the Widget Class Count from increasing if a widget is empty.


### Review checklist

[ ] I've reviewed the [contribution guidelines](https://github.com/bu-ist/coding-standards/blob/develop/CONTRIBUTING.md).
[ ] I've updated `CHANGELOG.MD` with a brief explanation of the changes in this pull request in the unreleased section.
[ ] My code follows [BU Coding Standards](https://github.com/bu-ist/coding-standards).
