### PR TITLE
Fix deprecated call to GFForms::setup

### DIFF
--- a/bu-site-init.php
+++ b/bu-site-init.php
@@ -168,7 +168,8 @@ function responsive_initialize_site( $site, $site_id, $admin_id, $domain, $path,
 		error_log( sprintf( '[%s] Creating contact form...', __FUNCTION__ ) );
 
 		// Install GF tables if they don't already exist.
-		GFForms::setup();
+		$current_gf_version = get_option( 'rg_form_version' );
+		gf_upgrade()->upgrade( $current_gf_version, true );
 
 		// Import template form.
 		$contact_form = json_decode( file_get_contents( get_template_directory() . '/inc/contact-form.json' ), true );


### PR DESCRIPTION
This is a requirement for being able to upgrade the Gravity Forms plugin which will happen during the WordPress core upgrade.

### Changes proposed in this pull request

- Fix deprecated call to GFForms::setup in newer version of GF

### Required pull requests to merge (usually a pull request on Foundation or a plugin)

- None

### Review checklist

[x] I've reviewed the [contribution guidelines](https://github.com/bu-ist/coding-standards/blob/develop/CONTRIBUTING.md).
[ ] I've updated `CHANGELOG.MD` with a brief explanation of the changes in this pull request in the unreleased section.
[x] My code follows [BU Coding Standards](https://github.com/bu-ist/coding-standards).
