### PR TITLE
fix deprecated GF call

### DIFF
--- a/bu-site-init.php
+++ b/bu-site-init.php
@@ -168,7 +168,8 @@ function responsive_initialize_site( $site, $site_id, $admin_id, $domain, $path,
 		error_log( sprintf( '[%s] Creating contact form...', __FUNCTION__ ) );
 
 		// Install GF tables if they don't already exist.
-		GFForms::setup();
+		$current_gf_version = get_option( 'rg_form_version' );
+		gf_upgrade()->upgrade( $current_gf_version, true );
 
 		// Import template form.
 		$contact_form = json_decode( file_get_contents( get_template_directory() . '/inc/contact-form.json' ), true );


### PR DESCRIPTION
Recreates https://github.com/bu-ist/responsive-framework-1x/pull/418 for this 2x repo as part of migrate process.

Confirmed this fix has been merged into 1x and is currently live.

**ashleykolodziej commented on Jun 19**
Looks fine to me, just need to test. Out of curiosity, is this something that we can fix/deploy before the upgrade without harming anything?This will have to be applied to both 1.0 and 2.0 by the looks of it.

**carlosesilva commented on Jun 19**
This cannot be deployed beforehand unfortunately and yes it will have to be applied to both.

**carlosesilva commented on Jun 19**
Here is the line that says it is deprecated:
https://github.com/wp-premium/gravityforms/blob/2.2.6/gravityforms.php#L4948

**ashleykolodziej commented on Jul 11**
Looks 👌 but this pull request will update 2.0, and will have to be moved over to the new repo to be made live. Can you open another pull request off the responsive-framework-1x branch in this repo? That will get this fixed in 1x, which I think is the biggest issue at hand.




