### PR TITLE
more PR 176 from 1x-develop to the 2x repo

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -328,14 +328,15 @@ function responsive_term_links( $post = null, $before = '', $sep = '', $after = 
  * If the current site has a site-wide ACL applied nothing will be displayed.
  *
  * @uses  BU Navigation plugin
+ * @param string $nav_id Allow override of the default primary nav id.
  */
-function responsive_primary_nav() {
+function responsive_primary_nav( $nav_id = 'primary-nav-menu' ) {
 	if ( ! method_exists( 'BuAccessControlPlugin', 'is_site_403' ) ||
 		false == BuAccessControlPlugin::is_site_403() ) {
 
 		if ( function_exists( 'bu_navigation_display_primary' ) ) {
 			bu_navigation_display_primary( array(
-				'container_id'    => 'primary-nav-menu',
+				'container_id'    => $nav_id,
 				'container_class' => 'primary-nav-menu',
 			) );
 		} else {
@@ -356,6 +357,7 @@ function responsive_primary_nav() {
  * If the current site has a site-wide ACL applied or the utility menu has
  * no items nothing will be displayed.
  *
+ * @param string $extra_classes Optional. Extra classes for the menu markup.
  * @param array $args {
  *     Optional. Arguments to configure menu markup.
  *
@@ -363,13 +365,18 @@ function responsive_primary_nav() {
  *     @type  string $after  HTML markup to display after menu.
  * }
  */
-function responsive_utility_nav( $args = array() ) {
+function responsive_utility_nav( $extra_classes = NULL, $args = array()) {
 	if ( ! has_nav_menu( 'utility' ) ) {
 		return;
 	}
 
+	$classes = 'utility-nav';
+	if ( $extra_classes ) {
+		$classes .= ' ' . $extra_classes;
+	}
+
 	$defaults = array(
-		'before' => '<nav class="utility-nav" role="navigation">',
+		'before' => '<nav class="' . $classes . '" role="navigation">',
 		'after'  => '</nav>',
 	);
 

--- a/template-parts/masthead-no-nav.php
+++ b/template-parts/masthead-no-nav.php
@@ -12,10 +12,10 @@
 	<p class="site-description brand-site-description"><?php bloginfo( 'description' ); ?></p>
 
 	<?php if ( responsive_search_is_enabled() ) : ?>
-		<button type="button" class="search-toggle js-search-toggle" aria-label="<?php esc_attr_e( 'Open search', 'responsive-framework' ); ?>" aria-expanded="true"><span><?php esc_html_e( 'Search', 'responsive-framework' ); ?></span></button>
+		<a href="#quicksearch" class="search-toggle search-toggle-nonav"><span>Search</span></a>
 	<?php endif; ?>
 </div>
 
-<?php responsive_utility_nav(); ?>
+<?php responsive_utility_nav( 'utility-nav-nonav' ); ?>
 
 <?php responsive_search_form();

--- a/template-parts/masthead-side-nav.php
+++ b/template-parts/masthead-side-nav.php
@@ -12,15 +12,15 @@
 	<p class="site-description brand-site-description"><?php bloginfo( 'description' ); ?></p>
 
 	<?php if ( responsive_search_is_enabled() ) : ?>
-		<button type="button" class="search-toggle js-search-toggle" aria-label="<?php esc_attr_e( 'Open search', 'responsive-framework' ); ?>" aria-expanded="true"><span><?php esc_html_e( 'Search', 'responsive-framework' ); ?></span></button>
+		<a href="#quicksearch" class="search-toggle search-toggle-sidenav"><span>Search</span></a>
 	<?php endif; ?>
 </div>
 
-<nav class="primary-nav" role="navigation">
-	<button type="button" class="nav-toggle js-nav-toggle" aria-label="<?php esc_attr_e( 'Open menu', 'responsive-framework' ); ?>" aria-expanded="true"><span><?php esc_html_e( 'Menu', 'responsive-framework' ); ?></span></button>
+<nav class="primary-nav primary-nav-sidenav" role="navigation">
+	<a href="#primary-nav-menu" class="nav-toggle nav-toggle-sidenav"><span class="nav-toggle-icon">Menu</span></a>
 
-	<?php responsive_primary_nav(); ?>
-	<?php responsive_utility_nav(); ?>
+	<?php responsive_primary_nav( 'primary-nav-menu-sidenav' ); ?>
+	<?php responsive_utility_nav( 'utility-nav-sidenav' ); ?>
 </nav>
 
 <?php

--- a/template-parts/masthead-top-nav.php
+++ b/template-parts/masthead-top-nav.php
@@ -6,16 +6,16 @@
  */
 
 ?>
-<nav class="primary-nav" role="navigation">
-	<button type="button" class="nav-toggle js-nav-toggle" aria-label="<?php esc_attr_e( 'Open menu', 'responsive-framework' ); ?>" aria-expanded="true"><span><?php esc_html_e( 'Menu', 'responsive-framework' ); ?></span></button>
+<nav class="primary-nav primary-nav-topnav" role="navigation">
+	<a href="#primary-nav-menu" class="nav-toggle nav-toggle-topnav"><span class="nav-toggle-icon">Menu</span></a>
 
 	<?php if ( responsive_search_is_enabled() ) : ?>
-		<button type="button" class="search-toggle js-search-toggle" aria-label="<?php esc_attr_e( 'Open search', 'responsive-framework' ); ?>" aria-expanded="true"><span><?php esc_html_e( 'Search', 'responsive-framework' ); ?></span></button>
+		<a href="#quicksearch" class="search-toggle search-toggle-topnav"><span>Search</span></a>
 	<?php endif; ?>
 
-	<?php responsive_primary_nav(); ?>
+	<?php responsive_primary_nav( 'primary-nav-menu-topnav' ); ?>
 
-	<?php responsive_utility_nav(); ?>
+	<?php responsive_utility_nav( 'utility-nav-topnav' ); ?>
 </nav>
 
 <?php responsive_search_form(); ?>

--- a/template-parts/masthead.php
+++ b/template-parts/masthead.php
@@ -12,7 +12,7 @@
 </div>
 
 <nav class="primary-nav" role="navigation">
-	<button type="button" class="nav-toggle js-nav-toggle" aria-label="<?php esc_attr_e( 'Open menu', 'responsive-framework' ); ?>" aria-expanded="true"><span><?php esc_html_e( 'Menu', 'responsive-framework' ); ?></span></button>
+	<a href="#primary-nav-menu" class="nav-toggle"><span class="nav-toggle-icon">Menu</span></a>
 
 	<?php if ( responsive_search_is_enabled() ) : ?>
 		<button type="button" class="search-toggle js-search-toggle" aria-label="<?php esc_attr_e( 'Open search', 'responsive-framework' ); ?>" aria-expanded="true"><span><?php esc_html_e( 'Search', 'responsive-framework' ); ?></span></button>


### PR DESCRIPTION
This recreated 176 https://github.com/bu-ist/bu-navigation/pull/30 in the 2x repo.

This needs to be reviewed and modified. It appears that the current 2x repo has advanced, and the `a` tags instead of `buttons` in this PR is an unwanted regression.

Also verify that the Navigation 30 referenced below is in place.


**ashleykolodziej commented on Mar 6, 2017**
Requires [bu-ist/bu-navigation#30](https://github.com/bu-ist/bu-navigation/pull/30)
