### PR TITLE
Remove bundle install from gruntfile

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@
 
 - Bower cleanup.
 - Fix font labeling in the customizer to match actual fonts.
+- Remove `bundle install` from package.json postinstall scripts.
 
 ## 2.1.10
 
 -	Update WordPress version in Travis tests to our current install version 4.9.7
 -	Update Unit Tests for `test_responsive_is_bu_domain_true()` to work with single
 	or multi-site installations.
--	Update deprecated Gravity Form call `GFForms::setup()` 
+-	Update deprecated Gravity Form call `GFForms::setup()`
 -	NPM Packages removed grunt-bowercopy.
 -	NPM Packages updated grunt-contrib-watch, grunt-modernizr, & lightgallery.
 -	Remove Ruby Sass gem.
@@ -365,4 +366,3 @@
 - Pre-release version of Responsi.
 - Child themes based on 0.9.1 include: r-cfa, r-hr, r-pardeeschool, r-research,
   and r-school.
-

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "time-grunt": "^1.4.0"
   },
   "scripts": {
-    "postinstall": "bundle install && grunt install"
+    "postinstall": "grunt install"
   },
   "dependencies": {}
 }


### PR DESCRIPTION
No longer need to run `bundle install` automatically since we are no longer using Ruby Sass.

See related issues:
https://github.com/bu-ist/responsive-framework/issues/7
https://github.com/bu-ist/responsive-framework/issues/54
https://github.com/bu-ist/responsive-framework/issues/122

Ruby Sass gem removed in this commit:
https://github.com/bu-ist/responsive-framework/pull/106/commits/a2fd9c4b1b8c99ef91d4c9857bda5ecc07f304ed

Grunt Sass was added in responsi-1x repo in this commit: https://github.com/bu-ist/responsive-framework-1x/commit/daca88ade97420985b693e151e9cda84fa05f87f#diff-b9cfc7f2cdf78a7f4b91a753d10865a2R25 and prior to that change, it was using grunt-contrib-sass v0.8.1 which required ruby sass.

Fixes #7, #54, #122.

### Changes proposed in this pull request

- Deletion of `bundle install` from running on npm install. It is only needed for Travis CI when wanting to setup Code Climate test coverage reporting, which Travis will use its `travis.yml` file for this functionality.

### Review checklist

[x] I've reviewed the [contribution guidelines](https://github.com/bu-ist/coding-standards/blob/develop/CONTRIBUTING.md).
[x] I've updated `CHANGELOG.MD` with a brief explanation of the changes in this pull request in the unreleased section.
[x] My code follows [BU Coding Standards](https://github.com/bu-ist/coding-standards).
