### PR TITLE
12 allow font options to be filtered

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Bower cleanup.
 - Fix font labeling in the customizer to match actual fonts.
+- Add filter for `responsive_font_options` for customizer fonts.
 - Remove `bundle install` from package.json postinstall scripts.
 - Upgrade `grunt-sass` from 2.0.0 to 3.0.2.
 - Print Stylesheet partial creation in Foundation: `/css-dev/burf-base/_print.scss`

--- a/bin/wpdc.sh
+++ b/bin/wpdc.sh
@@ -1,0 +1,65 @@
+#!/usr/bin/env bash
+
+# Remove any existing containers and volumes
+spin_down(){
+  printf "Cleaning up any existing containers\n\n"
+  docker-compose down -v
+}
+
+spin_up() {
+  # Read in extra parameters passed with the up command
+  PHP_VERSION=${1-latest}
+  WP_VERSION=${2-latest}
+
+  # Generate docker image tag from the PHP_VERSION variable
+  if [ $PHP_VERSION = 'latest' ]; then
+    WPDC_IMAGE_TAG=$PHP_VERSION
+  else
+    WPDC_IMAGE_TAG=php$PHP_VERSION
+  fi
+  export WPDC_IMAGE_TAG
+
+  set -e
+  # Remove any existing containers and volumes
+  spin_down
+  # Start docker containers. Pass in the WPDC_PHP_VERSION env variable to the docker-compose command.
+  printf "\nStarting up containers\n\n"
+  docker-compose up -d
+  # Wait for mysql container to spin up properly
+  printf '\nWaiting for mysql to properly boot up. This may take a little while...\n'
+  while ! docker-compose exec wptest mysqladmin ping -proot -h mysql --silent
+  do
+    sleep 1
+  done
+  # Run the install-wp-tests.sh script
+  printf "\nRunning bin/install-wp-tests.sh in container\n\n"
+  docker-compose exec wptest bash bin/install-wp-tests.sh wordpress_test root '' mysql $WP_VERSION
+  printf "\nSetup complete!\n"
+  printf "You may now modify your files and run your phpunit tests whenever you want by running: bash wpdc/wpdc.sh test\n"
+  printf "To stop and remove the containers and volumes created, run: bash wpdc/wpdc.sh down\n"
+}
+
+# Run phpunit in container
+run_phpunit(){
+  set -e
+  printf "Running single site tests\n\n"
+  docker-compose exec wptest bash -c "WP_MULTISITE=0 phpunit --exclude-group=ms-required"
+  printf "Running multisite tests\n\n"
+  docker-compose exec wptest bash -c "WP_MULTISITE=1 phpunit --exclude-group=ms-excluded"
+}
+
+
+case "$1" in
+  'up')
+    spin_up $2 $3
+    ;;
+  'down')
+    spin_down
+    ;;
+  'test')
+    run_phpunit
+    ;;
+  *)
+    echo $"Usage: bash $0 <up|down|test>"
+    exit 1
+esac

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+version: '3.1'
+services:
+  wptest:
+    image: carlosesilva/wp-phpunit-xdebug:${WPDC_IMAGE_TAG-latest}
+    volumes:
+      - .:/code
+    working_dir: /code
+  mysql:
+    image: mysql:5.7
+    environment:
+      MYSQL_ALLOW_EMPTY_PASSWORD: 'yes'

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -80,13 +80,25 @@ function responsive_get_font_palette() {
  * Returns font palette options available via Customizer.
  */
 function responsive_font_options() {
-	return array(
-		'f1' => '<span class="f1-font-title">Benton Bold</span><span class="f1-font-body">Benton Sans Regular is the font your body copy will appear in.</span>',
-		'f2' => '<span class="f2-font-title">Capita Bold</span><span class="f2-font-body">Benton Sans Regular is the font your body copy will appear in.</span>',
-		'f3' => '<span class="f3-font-title">Benton Light</span><span class="f3-font-body">Capita Regular is the font your body copy will appear in.</span>',
-		'f4' => '<span class="f4-font-title">Tiempos Bold</span><span class="f4-font-body">Tiempos Regular is the font your body copy will appear in.</span>',
-		'f5' => '<span class="f5-font-title">Pressura Heading</span><span class="f5-font-body">Benton Sans Regular is the font your body copy will appear in.</span>',
+
+	/**
+	 * Allow fonts to be filtered.
+	 *
+	 * @since 2.1.11
+	 *
+	 * @param array List of font family options.
+	 */
+	return (array) apply_filters(
+		'responsive_font_options',
+		array(
+			'f1' => '<span class="f1-font-title">Benton Bold</span><span class="f1-font-body">Benton Sans Regular is the font your body copy will appear in.</span>',
+			'f2' => '<span class="f2-font-title">Capita Bold</span><span class="f2-font-body">Benton Sans Regular is the font your body copy will appear in.</span>',
+			'f3' => '<span class="f3-font-title">Benton Light</span><span class="f3-font-body">Capita Regular is the font your body copy will appear in.</span>',
+			'f4' => '<span class="f4-font-title">Tiempos Bold</span><span class="f4-font-body">Tiempos Regular is the font your body copy will appear in.</span>',
+			'f5' => '<span class="f5-font-title">Pressura Heading</span><span class="f5-font-body">Benton Sans Regular is the font your body copy will appear in.</span>',
+		)
 	);
+
 }
 
 /**

--- a/tests/test-customizer.php
+++ b/tests/test-customizer.php
@@ -15,7 +15,7 @@ class Tests_Responsive_Framework_Customizer extends WP_UnitTestCase {
 	/**
 	 * Test default responsive font palette.
 	 */
-	function test_responsive_get_font_palette() {
+	public function test_responsive_get_font_palette() {
 		$this->assertEquals( 'f1', responsive_get_font_palette() );
 		update_option( 'burf_setting_fonts', 'f2' );
 		$this->assertEquals( 'f2', responsive_get_font_palette() );
@@ -25,7 +25,7 @@ class Tests_Responsive_Framework_Customizer extends WP_UnitTestCase {
 	/**
 	 * Test the default font palettes.
 	 */
-	function test_responsive_font_options() {
+	public function test_responsive_font_options() {
 		$font_options = array(
 			'f1' => '<span class="f1-font-title">Benton Bold</span><span class="f1-font-body">Benton Sans Regular is the font your body copy will appear in.</span>',
 			'f2' => '<span class="f2-font-title">Capita Bold</span><span class="f2-font-body">Benton Sans Regular is the font your body copy will appear in.</span>',
@@ -40,7 +40,7 @@ class Tests_Responsive_Framework_Customizer extends WP_UnitTestCase {
 	/**
 	 * Test the default font palettes, but filtered.
 	 */
-	function test_responsive_font_options_filtered() {
+	public function test_responsive_font_options_filtered() {
 
 		// Add filter to change the default font family values.
 		add_filter(
@@ -70,7 +70,7 @@ class Tests_Responsive_Framework_Customizer extends WP_UnitTestCase {
 	/**
 	 * Test the customizer style cache flush.
 	 */
-	function test_responsive_flush_customizer_styles_cache() {
+	public function test_responsive_flush_customizer_styles_cache() {
 		update_option( 'burf_customizer_styles', 'hey this is a test option' );
 		responsive_flush_customizer_styles_cache();
 		$this->assertEmpty( responsive_flush_customizer_styles_cache() );
@@ -79,7 +79,7 @@ class Tests_Responsive_Framework_Customizer extends WP_UnitTestCase {
 	/**
 	 * Test default color region sections.
 	 */
-	function test_responsive_customizer_color_region_groups() {
+	public function test_responsive_customizer_color_region_groups() {
 		$color_region_groups = array(
 			'navbar'       => array(
 				'label' => 'Navigation Bar',
@@ -102,14 +102,14 @@ class Tests_Responsive_Framework_Customizer extends WP_UnitTestCase {
 	/**
 	 * Test default optional color regions.
 	 */
-	function test_responsive_get_optional_color_regions() {
+	public function test_responsive_get_optional_color_regions() {
 		$this->assertEquals( array( 'sidebar-bg' ), responsive_get_optional_color_regions() );
 	}
 
 	/**
 	 * Test color scheme sanitization.
 	 */
-	function test_responsive_sanitize_color_scheme() {
+	public function test_responsive_sanitize_color_scheme() {
 		$this->assertEquals( 'default', responsive_sanitize_color_scheme( 'default' ) );
 		$this->assertEquals( 'slacker', responsive_sanitize_color_scheme( 'slacker' ) );
 		$this->assertEquals( 'default', responsive_sanitize_color_scheme( 'non-existant-scheme' ) );
@@ -118,7 +118,7 @@ class Tests_Responsive_Framework_Customizer extends WP_UnitTestCase {
 	/**
 	 * Test default color scheme choices.
 	 */
-	function test_responsive_get_color_scheme_choices() {
+	public function test_responsive_get_color_scheme_choices() {
 		$this->assertEquals( responsive_get_color_scheme_choices(), array(
 			'default' => 'Default',
 			'slacker' => 'Slacker',
@@ -133,7 +133,7 @@ class Tests_Responsive_Framework_Customizer extends WP_UnitTestCase {
 	/**
 	 * Test correct color scheme is returned.
 	 */
-	function test_responsive_get_color_scheme() {
+	public function test_responsive_get_color_scheme() {
 		$this->assertEquals( 'Default', responsive_get_color_scheme()['label'] );
 		$this->assertEquals( 'Vinca Minor', responsive_get_color_scheme( 'vinca-minor' )['label'] );
 	}
@@ -141,7 +141,7 @@ class Tests_Responsive_Framework_Customizer extends WP_UnitTestCase {
 	/**
 	 * Theme and framework version constants.
 	 */
-	function test_responsive_get_custom_colors() {
+	public function test_responsive_get_custom_colors() {
 		$test_values = array( 'primaryNav-bg' => '#c2185b', 'primaryNav-border' => '#cd4279' );
 
 		$this->assertEquals( array(), responsive_get_custom_colors() );

--- a/tests/test-customizer.php
+++ b/tests/test-customizer.php
@@ -38,6 +38,36 @@ class Tests_Responsive_Framework_Customizer extends WP_UnitTestCase {
 	}
 
 	/**
+	 * Test the default font palettes, but filtered.
+	 */
+	function test_responsive_font_options_filtered() {
+
+		// Add filter to change the default font family values.
+		add_filter(
+			'responsive_font_options',
+			function( $fonts ) {
+				// Remove the first option for testing.
+				unset( $fonts['f1'] );
+				// Add a new font for testing.
+				$fonts['new_font'] = '<span class="new_font-font-title">New Font</span><span class="new_font-font-body">New Font is the font your body copy will appear in.</span>';
+				return $fonts;
+			}
+		);
+
+		// Define the expected result of this filter.
+		$expected = array(
+			'f2'       => '<span class="f2-font-title">Capita Bold</span><span class="f2-font-body">Benton Sans Regular is the font your body copy will appear in.</span>',
+			'f3'       => '<span class="f3-font-title">Benton Light</span><span class="f3-font-body">Capita Regular is the font your body copy will appear in.</span>',
+			'f4'       => '<span class="f4-font-title">Tiempos Bold</span><span class="f4-font-body">Tiempos Regular is the font your body copy will appear in.</span>',
+			'f5'       => '<span class="f5-font-title">Pressura Heading</span><span class="f5-font-body">Benton Sans Regular is the font your body copy will appear in.</span>',
+			'new_font' => '<span class="new_font-font-title">New Font</span><span class="new_font-font-body">New Font is the font your body copy will appear in.</span>',
+		);
+
+		$this->assertEquals( $expected, responsive_font_options() );
+
+	}
+
+	/**
 	 * Test the customizer style cache flush.
 	 */
 	function test_responsive_flush_customizer_styles_cache() {


### PR DESCRIPTION
Fixes #12

### Changes proposed in this pull request

- Adds a new filter for the function `responsive_font_options` for modifying the default fonts allowed in the customizer.
- Adds PHPUnit test for this filter.
- Adds docker setup for running PHPUnit tests locally.

### Review checklist

[x] I've reviewed the [contribution guidelines](https://github.com/bu-ist/coding-standards/blob/develop/CONTRIBUTING.md).
[x] I've updated `CHANGELOG.MD` with a brief explanation of the changes in this pull request in the unreleased section.
[x] My code follows [BU Coding Standards](https://github.com/bu-ist/coding-standards).
