### PR TITLE
13 allow fallback font to be filterable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,8 @@
 - Bower cleanup.
 - Fix font labeling in the customizer to match actual fonts.
 - Add filter for `responsive_font_options` for customizer fonts.
+- Add filter for `responsive_get_font_palette` for when `f1` no longer exists
+  and a value hasn't been set yet.
 - Remove `bundle install` from package.json postinstall scripts.
 - Upgrade `grunt-sass` from 2.0.0 to 3.0.2.
 - Print Stylesheet partial creation in Foundation: `/css-dev/burf-base/_print.scss`

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -67,13 +67,24 @@ function responsive_layout_options() {
 
 /**
  * Returns the site's current font palette.
+ *
+ * @return string The value for the font palette to be used.
  */
 function responsive_get_font_palette() {
 	if ( defined( 'BU_RESPONSIVE_FONT_PALETTE' ) && array_key_exists( BU_RESPONSIVE_FONT_PALETTE, responsive_font_options() ) ) {
 		return BU_RESPONSIVE_FONT_PALETTE;
 	}
 
-	return get_option( 'burf_setting_fonts', 'f1' );
+	/**
+	 * Allow the fallback font to be filtered.
+	 *
+	 * @since 2.1.11
+	 *
+	 * @param string Fallback font value.
+	 */
+	$fallback_font = (string) apply_filters( 'responsive_font_fallback', 'f1' );
+
+	return get_option( 'burf_setting_fonts', $fallback_font );
 }
 
 /**

--- a/tests/test-customizer.php
+++ b/tests/test-customizer.php
@@ -65,6 +65,16 @@ class Tests_Responsive_Framework_Customizer extends WP_UnitTestCase {
 
 		$this->assertEquals( $expected, responsive_font_options() );
 
+		// Test the fallback font value if none set in Options table.
+		add_filter(
+			'responsive_font_fallback',
+			function( $fallback_font ) {
+				$fallback_font = 'new_font';
+				return $fallback_font;
+			}
+		);
+		$this->assertEquals( 'new_font', responsive_get_font_palette() );
+
 	}
 
 	/**


### PR DESCRIPTION
Fixes #13.

### Changes proposed in this pull request

Adds a new filter, `responsive_font_fallback` that accepts a string as the parameter set to `f1` by default. This filter is called when the function `responsive_get_font_palette` is called. This is useful in scenarios where the original font palette has been replaced or modified, and `f1` is no longer an option. In that use-case, this filter can be used to change the default font palette value returned when a value couldn't be retrieved using `get_option( 'burf_setting_fonts' )`.

### Review checklist

[x] I've reviewed the [contribution guidelines](https://github.com/bu-ist/coding-standards/blob/develop/CONTRIBUTING.md).
[x] I've updated `CHANGELOG.MD` with a brief explanation of the changes in this pull request in the unreleased section.
[x] My code follows [BU Coding Standards](https://github.com/bu-ist/coding-standards).
