### PR TITLE
Moved BU-specific nav from template-tags / added filter to override defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - Remove `bundle install` from package.json postinstall scripts.
 - Upgrade `grunt-sass` from 2.0.0 to 3.0.2.
 - Print Stylesheet partial creation in Foundation: `/css-dev/burf-base/_print.scss`
+- Add filter to alllow for modification of `bu_navigation_display_primary` defaults from within framework.
 
 ## 2.1.11
 

--- a/functions.php
+++ b/functions.php
@@ -819,6 +819,7 @@ require __DIR__ . '/inc/search-form.php';
  * Reusable template tags to keep templates logic-free.
  */
 require __DIR__ . '/inc/template-tags.php';
+require __DIR__ . '/inc/bu-template-tags.php'; // BU enhancements to template-tags.
 
 /**
  * Upgrade routines for schema changes across versions.

--- a/functions.php
+++ b/functions.php
@@ -818,8 +818,8 @@ require __DIR__ . '/inc/search-form.php';
 /**
  * Reusable template tags to keep templates logic-free.
  */
-require __DIR__ . '/inc/template-tags.php';
 require __DIR__ . '/inc/bu-template-tags.php'; // BU enhancements to template-tags.
+require __DIR__ . '/inc/template-tags.php';
 
 /**
  * Upgrade routines for schema changes across versions.

--- a/inc/bu-template-tags.php
+++ b/inc/bu-template-tags.php
@@ -1,0 +1,33 @@
+<?php
+/**
+ * BU Specific functionality
+ * expanding from template-tags.php
+ */
+function bu_responsive_primary_nav( $nav ) {
+	if ( ! method_exists( 'BuAccessControlPlugin', 'is_site_403' ) || false === BuAccessControlPlugin::is_site_403() ) {
+
+		if ( function_exists( 'bu_navigation_display_primary' ) ) {
+			$args = apply_filters( 'bu_responsive_primary_nav_args', array(
+				'post_types'      => array( 'page' ),
+				'include_links'   => true,
+				'depth'           => BU_NAVIGATION_PRIMARY_DEPTH,
+				'max_items'       => BU_NAVIGATION_PRIMARY_MAX,
+				'dive'            => true,
+				'container_tag'   => 'ul',
+				'container_id'    => 'primary-nav-menu',
+				'container_class' => 'primary-nav-menu',
+				'item_tag'        => 'li',
+				'identify_top'    => false,
+				'whitelist_top'   => null,
+				'title_before'    => '',
+				'title_after'     => '',
+				'echo'            => false,
+			) );
+
+			$nav = bu_navigation_display_primary( $args );
+		}
+	}
+
+	return $nav;
+}
+add_filter( 'responsive_primary_nav', 'bu_responsive_primary_nav' );

--- a/inc/bu-template-tags.php
+++ b/inc/bu-template-tags.php
@@ -3,10 +3,21 @@
  * BU Specific functionality
  * expanding from template-tags.php
  */
-function bu_responsive_primary_nav( $nav ) {
+
+/**
+ * Override the default navigation menu with
+ * BU custom version.
+ *
+ * @param string $nav Default HTML markup for the navigation.
+ * @param array $args Default Responsive Framework nav arguments.
+ */
+function responsive_primary_nav() {
 	if ( ! method_exists( 'BuAccessControlPlugin', 'is_site_403' ) || false === BuAccessControlPlugin::is_site_403() ) {
 
 		if ( function_exists( 'bu_navigation_display_primary' ) ) {
+			/**
+			 * Filters the BU navigation defaults.
+			 */
 			$args = apply_filters( 'bu_responsive_primary_nav_args', array(
 				'post_types'      => array( 'page' ),
 				'include_links'   => true,
@@ -21,13 +32,9 @@ function bu_responsive_primary_nav( $nav ) {
 				'whitelist_top'   => null,
 				'title_before'    => '',
 				'title_after'     => '',
-				'echo'            => false,
 			) );
 
-			$nav = bu_navigation_display_primary( $args );
+			bu_navigation_display_primary( $args );
 		}
 	}
-
-	return $nav;
 }
-add_filter( 'responsive_primary_nav', 'bu_responsive_primary_nav' );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -323,23 +323,24 @@ function responsive_term_links( $post = null, $before = '', $sep = '', $after = 
 }
 
 /**
- * Renders the primary navigation menu.
- *
- * If the current site has a site-wide ACL applied nothing will be displayed.
- *
- * @uses  BU Navigation plugin
+ * Renders the primary navigation menu with custom id and class.
+ * It can be overridden in the child theme.
  */
-function responsive_primary_nav() {
-	$nav = apply_filters( 'responsive_primary_nav', wp_nav_menu( array(
-		'theme_location' => 'responsive-primary',
-		'menu_id'        => 'primaryNav-menu',
-		'menu_class'     => 'primaryNav-menu',
-		'container_tag'  => 'ul',
-		'depth'          => 2,
-		'echo'           => false,
-	) ) );
+if ( ! function_exists( 'responsive_primary_nav' ) ) {
+	function responsive_primary_nav() {
+		/**
+		 * Filters the responsive framework default nav options.
+		 */
+		$args = apply_filters( 'responsive_primary_nav_args', array(
+			'theme_location' => 'responsive-primary',
+			'menu_id'        => 'primaryNav-menu',
+			'menu_class'     => 'primaryNav-menu',
+			'container_tag'  => 'ul',
+			'depth'          => 2,
+		) );
 
-	echo $nav;
+		wp_nav_menu( $args );
+	}
 }
 
 /**

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -330,24 +330,16 @@ function responsive_term_links( $post = null, $before = '', $sep = '', $after = 
  * @uses  BU Navigation plugin
  */
 function responsive_primary_nav() {
-	if ( ! method_exists( 'BuAccessControlPlugin', 'is_site_403' ) ||
-		false == BuAccessControlPlugin::is_site_403() ) {
+	$nav = apply_filters( 'responsive_primary_nav', wp_nav_menu( array(
+		'theme_location' => 'responsive-primary',
+		'menu_id'        => 'primaryNav-menu',
+		'menu_class'     => 'primaryNav-menu',
+		'container_tag'  => 'ul',
+		'depth'          => 2,
+		'echo'           => false,
+	) ) );
 
-		if ( function_exists( 'bu_navigation_display_primary' ) ) {
-			bu_navigation_display_primary( array(
-				'container_id'    => 'primary-nav-menu',
-				'container_class' => 'primary-nav-menu',
-			) );
-		} else {
-			wp_nav_menu( array(
-				'theme_location' => 'responsive-primary',
-				'menu_id'        => 'primaryNav-menu',
-				'menu_class'     => 'primaryNav-menu',
-				'container_tag'  => 'ul',
-				'depth'          => 2,
-			) );
-		}
-	}
+	echo $nav;
 }
 
 /**


### PR DESCRIPTION
Fixes #132 

### Changes proposed in this pull request

- Create `bu-template-tags.php`

- Move BU specific code out of `responsive_primary_nav`

- Add a filter in its place

- Create a filter in `bu-template-tags.php` to accommodate the BU code

- Add in default fields from `bu_navigation_display_primary`, wrapped in a `apply_filters` hook

### Review checklist

[x] I've reviewed the [contribution guidelines](https://github.com/bu-ist/coding-standards/blob/develop/CONTRIBUTING.md).
[x] I've updated `CHANGELOG.MD` with a brief explanation of the changes in this pull request in the unreleased section.
[x] My code follows [BU Coding Standards](https://github.com/bu-ist/coding-standards).
