### PR TITLE
Feature/responsive nav action hooks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,10 @@
 - Added mega navigation menu to customizer
 - Added new masthead markup for mega nav
 - Added new menu location for "short" nav
-- Add filter to alllow for modification of `bu_navigation_display_primary` defaults from within framework.
+- Add filter to alllow for modification of `bu_navigation_display_primary`
+  defaults from within framework.
+- Add before/after action hooks for the `responsive_primary_nav` and
+  `responsive_utility_nav`, so additional markup can be added by child themes.
 
 ## 2.1.11
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -322,12 +322,19 @@ function responsive_term_links( $post = null, $before = '', $sep = '', $after = 
 	return $output;
 }
 
-/**
- * Renders the primary navigation menu with custom id and class.
- * It can be overridden in the child theme.
- */
 if ( ! function_exists( 'responsive_primary_nav' ) ) {
+	/**
+	 * Renders the primary navigation menu with custom id and class.
+	 * It can be overridden in the child theme.
+	 */
 	function responsive_primary_nav() {
+		/**
+		 * Fires before primary nav is displayed.
+		 *
+		 * @since 2.11.12
+		 */
+		do_action( 'responsive_primary_nav_before' );
+
 		/**
 		 * Filters the responsive framework default nav options.
 		 */
@@ -340,6 +347,13 @@ if ( ! function_exists( 'responsive_primary_nav' ) ) {
 		) );
 
 		wp_nav_menu( $args );
+
+		/**
+		 * Fires after primary nav is displayed.
+		 *
+		 * @since 2.11.12
+		 */
+		do_action( 'responsive_primary_nav_after' );
 	}
 }
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -357,8 +357,41 @@ if ( ! function_exists( 'responsive_primary_nav' ) ) {
  * }
  */
 function responsive_utility_nav( $args = array() ) {
+	/**
+	 * Fires before utility nav is displayed.
+	 *
+	 * @since 2.11.12
+	 */
+	do_action( 'responsive_utility_nav_before' );
+
+	// Displays utility nav if exists.
+	$menu = responsive_get_utility_nav( $args );
+	if ( ! empty( $menu ) ) {
+		echo $menu; // wpcs: xss ok.
+	}
+
+	/**
+	 * Fires after utility nav is displayed.
+	 *
+	 * @since 2.11.12
+	 */
+	do_action( 'responsive_utility_nav_after' );
+}
+
+/**
+ * Fetches the utility nav, if exists.
+ *
+ * @since 2.11.12
+ *
+ * @see   responsive_utility_nav
+ *
+ * @param array $args Same arguments as responsive_utility_nav.
+ * @return string $menu The resulting menu markup.
+ */
+function responsive_get_utility_nav( $args = array() ) {
+
 	if ( ! has_nav_menu( 'utility' ) ) {
-		return;
+		return false;
 	}
 
 	$defaults = array(
@@ -370,18 +403,22 @@ function responsive_utility_nav( $args = array() ) {
 	$menu = '';
 
 	if ( ! method_exists( 'BuAccessControlPlugin', 'is_site_403' ) || false == BuAccessControlPlugin::is_site_403() ) {
-		$menu = wp_nav_menu( array(
-			'theme_location' => 'utility',
-			'menu_id'        => 'utility-nav-menu',
-			'menu_class'     => 'utility-nav-menu',
-			'container'      => false,
-			'echo'           => false,
-		) );
+		$menu = wp_nav_menu(
+			array(
+				'theme_location' => 'utility',
+				'menu_id'        => 'utility-nav-menu',
+				'menu_class'     => 'utility-nav-menu',
+				'container'      => false,
+				'echo'           => false,
+			)
+		);
 	}
 
 	if ( $menu ) {
-		echo $args['before'] . $menu . $args['after'];
+		$menu = $args['before'] . $menu . $args['after'];
 	}
+
+	return $menu;
 }
 
 /**

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -343,82 +343,86 @@ if ( ! function_exists( 'responsive_primary_nav' ) ) {
 	}
 }
 
-/**
- * Renders utility navigation menu.
- *
- * If the current site has a site-wide ACL applied or the utility menu has
- * no items nothing will be displayed.
- *
- * @param array $args {
- *     Optional. Arguments to configure menu markup.
- *
- *     @type  string $before HTML markup to display before menu.
- *     @type  string $after  HTML markup to display after menu.
- * }
- */
-function responsive_utility_nav( $args = array() ) {
+if ( ! function_exists( 'responsive_utility_nav' ) ) {
 	/**
-	 * Fires before utility nav is displayed.
+	 * Renders utility navigation menu.
 	 *
-	 * @since 2.11.12
+	 * If the current site has a site-wide ACL applied or the utility menu has
+	 * no items nothing will be displayed.
+	 *
+	 * @param array $args {
+	 *     Optional. Arguments to configure menu markup.
+	 *
+	 *     @type  string $before HTML markup to display before menu.
+	 *     @type  string $after  HTML markup to display after menu.
+	 * }
 	 */
-	do_action( 'responsive_utility_nav_before' );
+	function responsive_utility_nav( $args = array() ) {
+		/**
+		 * Fires before utility nav is displayed.
+		 *
+		 * @since 2.11.12
+		 */
+		do_action( 'responsive_utility_nav_before' );
 
-	// Displays utility nav if exists.
-	$menu = responsive_get_utility_nav( $args );
-	if ( ! empty( $menu ) ) {
-		echo $menu; // wpcs: xss ok.
+		// Displays utility nav if exists.
+		$menu = responsive_get_utility_nav( $args );
+		if ( ! empty( $menu ) ) {
+			echo $menu; // wpcs: xss ok.
+		}
+
+		/**
+		 * Fires after utility nav is displayed.
+		 *
+		 * @since 2.11.12
+		 */
+		do_action( 'responsive_utility_nav_after' );
 	}
-
-	/**
-	 * Fires after utility nav is displayed.
-	 *
-	 * @since 2.11.12
-	 */
-	do_action( 'responsive_utility_nav_after' );
 }
 
-/**
- * Fetches the utility nav, if exists.
- *
- * @since 2.11.12
- *
- * @see   responsive_utility_nav
- *
- * @param array $args Same arguments as responsive_utility_nav.
- * @return string $menu The resulting menu markup.
- */
-function responsive_get_utility_nav( $args = array() ) {
+if ( ! function_exists( 'responsive_get_utility_nav' ) ) {
+	/**
+	 * Fetches the utility nav, if exists.
+	 *
+	 * @since 2.11.12
+	 *
+	 * @see   responsive_utility_nav
+	 *
+	 * @param array $args Same arguments as responsive_utility_nav.
+	 * @return string $menu The resulting menu markup.
+	 */
+	function responsive_get_utility_nav( $args = array() ) {
 
-	if ( ! has_nav_menu( 'utility' ) ) {
-		return false;
-	}
+		if ( ! has_nav_menu( 'utility' ) ) {
+			return false;
+		}
 
-	$defaults = array(
-		'before' => '<nav class="utility-nav" role="navigation">',
-		'after'  => '</nav>',
-	);
-
-	$args = wp_parse_args( $args, $defaults );
-	$menu = '';
-
-	if ( ! method_exists( 'BuAccessControlPlugin', 'is_site_403' ) || false == BuAccessControlPlugin::is_site_403() ) {
-		$menu = wp_nav_menu(
-			array(
-				'theme_location' => 'utility',
-				'menu_id'        => 'utility-nav-menu',
-				'menu_class'     => 'utility-nav-menu',
-				'container'      => false,
-				'echo'           => false,
-			)
+		$defaults = array(
+			'before' => '<nav class="utility-nav" role="navigation">',
+			'after'  => '</nav>',
 		);
-	}
 
-	if ( $menu ) {
-		$menu = $args['before'] . $menu . $args['after'];
-	}
+		$args = wp_parse_args( $args, $defaults );
+		$menu = '';
 
-	return $menu;
+		if ( ! method_exists( 'BuAccessControlPlugin', 'is_site_403' ) || false == BuAccessControlPlugin::is_site_403() ) {
+			$menu = wp_nav_menu(
+				array(
+					'theme_location' => 'utility',
+					'menu_id'        => 'utility-nav-menu',
+					'menu_class'     => 'utility-nav-menu',
+					'container'      => false,
+					'echo'           => false,
+				)
+			);
+		}
+
+		if ( $menu ) {
+			$menu = $args['before'] . $menu . $args['after'];
+		}
+
+		return $menu;
+	}
 }
 
 /**


### PR DESCRIPTION
Adds action hooks that always get called whenever `responsive_primary_nav` or `responsive_utility_nav` get called.

The intent of these action hooks is to reduce the amount of times we'll need to override a masthead template partial in child themes due to additional markup. By adding before/after action hooks for these two menus, we can shoehorn additional utility menus where we need.

I'm using one of the action hooks, `responsive_utility_nav_before` in my sandbox: http://milliktr.cms-devl.bu.edu/r-cas-companion/

### Changes proposed in this pull request
- Add before/after action hooks to `responsive_utility_nav` and `responsive_primary_nav`.
- Add new `responsive_get_utility_nav` function which will only return the nav menu if exists, rather than returning before any action hooks can run. This allows the action hooks to still be used even when the utility nav is missing.
- Allow utility nav functions to be overridden by child themes.

### Review checklist

- [x] I've reviewed the [contribution guidelines](https://github.com/bu-ist/coding-standards/blob/develop/CONTRIBUTING.md).
- [x] I've updated `CHANGELOG.MD` with a brief explanation of the changes in this pull request in the unreleased section.
- [x] My code follows [BU Coding Standards](https://github.com/bu-ist/coding-standards).
