### PR TITLE
Removed the option for 'dive' to be filterable.

### DIFF
--- a/inc/bu-template-tags.php
+++ b/inc/bu-template-tags.php
@@ -23,7 +23,6 @@ function responsive_primary_nav() {
 				'include_links'   => true,
 				'depth'           => BU_NAVIGATION_PRIMARY_DEPTH,
 				'max_items'       => BU_NAVIGATION_PRIMARY_MAX,
-				'dive'            => true,
 				'container_tag'   => 'ul',
 				'container_id'    => 'primary-nav-menu',
 				'container_class' => 'primary-nav-menu',


### PR DESCRIPTION
Since it can be overridden in an options page, this doesn't need to be filtered.