### PR TITLE
Updates missing utility prefix on visually hidden

### DIFF
--- a/functions.php
+++ b/functions.php
@@ -732,7 +732,7 @@ function r_remove_news_template( $templates, $theme, $post ) {
  */
 function responsive_branding_copyright() {
 	?>
-		<div class="bu_copyright visually-hidden">&copy; <?php date( 'Y' ); ?> Boston&nbsp;University. All&nbsp;rights&nbsp;reserved. www.bu.edu</div>
+		<div class="bu_copyright u-visually-hidden">&copy; <?php date( 'Y' ); ?> Boston&nbsp;University. All&nbsp;rights&nbsp;reserved. www.bu.edu</div>
 	<?php
 }
 


### PR DESCRIPTION
Minor tweak to the visually hidden class on the copyright so it actually hides.

@hirozed can you upload this change to your sandbox and make sure the copyright on Dining's footer is hidden after?