### PR TITLE
Feature/footer template parts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+- Move footer-branding and footer-menus to their own template partials for
+  easier child theme overrides.
+
 ## 2.1.13
 
 - Minor update to change how content was checked for banners, switching to the bu_banners spefic `has_text`.

--- a/footer.php
+++ b/footer.php
@@ -60,25 +60,7 @@
 
 	<footer class="site-footer <?php responsive_extra_footer_classes(); ?>" role="contentinfo">
 		<?php get_template_part( 'template-parts/footer-branding' ); ?>
-		<?php
-			/**
-			 * Fires immediately before the footer menus.
-			 */
-			do_action( 'r_before_footer_menus' );
-		?>
-		<div class="site-footer-menus">
-			<?php responsive_footer_menu(); ?>
-			<?php responsive_social_menu(); ?>
-		</div>
-		<?php
-			/**
-			 * Fires immediately after the footer menus.
-			 *
-			 * @since 2.0.0
-			 */
-			do_action( 'r_after_footer_menus' );
-		?>
-
+		<?php get_template_part( 'template-parts/footer-menus' ); ?>
 	</footer>
 
 	<?php wp_footer(); ?>

--- a/footer.php
+++ b/footer.php
@@ -59,29 +59,7 @@
 	?>
 
 	<footer class="site-footer <?php responsive_extra_footer_classes(); ?>" role="contentinfo">
-		<?php
-			/**
-			 * Fires immediately before the footer brand assets.
-			 *
-			 * @since 2.0.0
-			 */
-			do_action( 'r_before_footer_brand_assets' );
-		?>
-		<div class="site-footer-brand-assets">
-			<?php responsive_branding_masterplate(); ?>
-			<?php responsive_branding_bumc_logo(); ?>
-			<?php responsive_branding_disclaimer(); ?>
-			<?php responsive_customizer_footer_info(); ?>
-		</div>
-		<?php
-			/**
-			 * Fires immediately after the footer brand assets.
-			 *
-			 * @since 2.0.0
-			 */
-			do_action( 'r_after_footer_brand_assets' );
-		?>
-
+		<?php get_template_part( 'template-parts/footer-branding' ); ?>
 		<?php
 			/**
 			 * Fires immediately before the footer menus.

--- a/template-parts/footer-branding.php
+++ b/template-parts/footer-branding.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Footer branding partial
+ *
+ * @package Responsive_Framework
+ */
+
+/**
+ * Fires immediately before the footer brand assets.
+ *
+ * @since 2.0.0
+ */
+do_action( 'r_before_footer_brand_assets' );
+
+?>
+<div class="site-footer-brand-assets">
+	<?php responsive_branding_masterplate(); ?>
+	<?php responsive_branding_bumc_logo(); ?>
+	<?php responsive_branding_disclaimer(); ?>
+	<?php responsive_customizer_footer_info(); ?>
+</div>
+<?php
+
+/**
+ * Fires immediately after the footer brand assets.
+ *
+ * @since 2.0.0
+ */
+do_action( 'r_after_footer_brand_assets' );

--- a/template-parts/footer-menus.php
+++ b/template-parts/footer-menus.php
@@ -1,0 +1,27 @@
+<?php
+/**
+ * Footer menus partial
+ *
+ * @package Responsive_Framework
+ */
+
+/**
+ * Fires immediately before the footer menus.
+ *
+ * @since 2.0.0
+ */
+do_action( 'r_before_footer_menus' );
+
+?>
+<div class="site-footer-menus">
+	<?php responsive_footer_menu(); ?>
+	<?php responsive_social_menu(); ?>
+</div>
+<?php
+
+/**
+ * Fires immediately after the footer menus.
+ *
+ * @since 2.0.0
+ */
+do_action( 'r_after_footer_menus' );


### PR DESCRIPTION
### Changes proposed in this pull request

- Move parts that are hardcoded in `footer.php` out into template partials, so child themes can override parts of the footer without overriding the entire footer.
- Adds a new template partial, `template-parts/footer-branding.php`.
- Adds a new template partial, `template-parts/footer-menus.php`.

This is a non-breaking change since it is just breaking down the footer into smaller chunks. I did a quick scan of the repo and there aren't any conflicts of child themes having these partials, so things will just work as they always have been. The only benefit here is for developers who want to override parts of the footer without overriding the whole `footer.php` file.

### Example of this need
I needed to provide my own branding partial for the `r-cas-companion` theme that would always output written text for Boston University, in addition to the branding parent, subparent (optional), and branding title. See attached screenshot.

![screen shot 2019-02-22 at 11 26 26 am](https://user-images.githubusercontent.com/26465346/53264374-69911700-36a9-11e9-8529-99bf226fb6e6.png)

[See this PR on `r-cas-companion` child theme](https://github.com/bu-ist/r-cas-companion/pull/18) that overrides the `template-parts/footer-branding.php` partial for a working example.

### Review checklist

- [x] I've reviewed the [contribution guidelines](https://github.com/bu-ist/coding-standards/blob/develop/CONTRIBUTING.md).
- [x] I've updated `CHANGELOG.MD` with a brief explanation of the changes in this pull request in the unreleased section.
- [x] My code follows [BU Coding Standards](https://github.com/bu-ist/coding-standards).
