### PR TITLE
Feature/fix responsive get posts archive link notices

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Changelog
 
+## Unreleased
+
+- Resolve PHP Warnings when `responsive_get_posts_archive_link` is called on a
+  page that doesn't have any categories assigned to it.
+
 ## 2.2.0
 
 - Move footer-branding and footer-menus to their own template partials for

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -816,19 +816,22 @@ function responsive_get_posts_archive_link() {
 		'meta_value'   => 'page-templates/news.php',
 	) );
 
-	foreach( $news_pages as $page ) {
-		$page_cat_id = get_post_meta( $page->ID, '_bu_list_news_category', true );
+	// Only iterates through pages if they exist.
+	if ( ! empty( $news_pages ) ) {
+		foreach ( $news_pages as $page ) {
+			$page_cat_id = get_post_meta( $page->ID, '_bu_list_news_category', true );
 
-		if ( in_array( $page_cat_id, $post_cat_ids ) ) {
-			$archive_link = get_permalink( $page->ID );
-			break;
-		}
+			if ( in_array( $page_cat_id, $post_cat_ids ) ) {
+				$archive_link = get_permalink( $page->ID );
+				break;
+			}
 
-		// Find the first news page set to display "All Categories".
-		// Hold onto it in case we can't find a page that matches the category.
-		if ( empty( $page_cat_id ) && ! $all_cats ) {
-			$all_cats = get_permalink( $page->ID );
-			continue;
+			// Find the first news page set to display "All Categories".
+			// Hold onto it in case we can't find a page that matches the category.
+			if ( empty( $page_cat_id ) && ! $all_cats ) {
+				$all_cats = get_permalink( $page->ID );
+				continue;
+			}
 		}
 	}
 

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -801,8 +801,13 @@ function responsive_posts_should_display( $field ) {
 function responsive_get_posts_archive_link() {
 	$archive_link = false;
 	$post_cats = get_the_terms( get_post(), 'category' );
-	$post_cat_ids = wp_list_pluck( $post_cats, 'term_id' );
+	$post_cat_ids = array();
 	$all_cats = false;
+
+	// Sets $post_cat_ids if categories exist for this post.
+	if ( ! empty( $post_cats ) && ! is_wp_error( $post_cats ) ) {
+		$post_cat_ids = wp_list_pluck( $post_cats, 'term_id' );
+	}
 
 	$news_pages = get_pages( array(
 		'hierarchical' => 0,

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -799,29 +799,33 @@ function responsive_posts_should_display( $field ) {
  * @return mixed Post archive link, or false if no good candidates were found.
  */
 function responsive_get_posts_archive_link() {
+	// Sets initial values.
 	$archive_link = false;
-	$post_cats = get_the_terms( get_post(), 'category' );
+	$post_cats    = get_the_terms( get_post(), 'category' );
 	$post_cat_ids = array();
-	$all_cats = false;
+	$all_cats     = false;
 
 	// Sets $post_cat_ids if categories exist for this post.
 	if ( ! empty( $post_cats ) && ! is_wp_error( $post_cats ) ) {
 		$post_cat_ids = wp_list_pluck( $post_cats, 'term_id' );
 	}
 
-	$news_pages = get_pages( array(
-		'hierarchical' => 0,
-		'parent' => -1,
-		'meta_key'     => '_wp_page_template',
-		'meta_value'   => 'page-templates/news.php',
-	) );
+	// Runs the query to retrieve custom news page templates.
+	$news_pages = get_pages(
+		array(
+			'hierarchical' => 0,
+			'parent'       => -1,
+			'meta_key'     => '_wp_page_template',
+			'meta_value'   => 'page-templates/news.php',
+		)
+	);
 
 	// Only iterates through pages if they exist.
 	if ( ! empty( $news_pages ) ) {
 		foreach ( $news_pages as $page ) {
 			$page_cat_id = get_post_meta( $page->ID, '_bu_list_news_category', true );
 
-			if ( in_array( $page_cat_id, $post_cat_ids ) ) {
+			if ( in_array( $page_cat_id, $post_cat_ids, true ) ) {
 				$archive_link = get_permalink( $page->ID );
 				break;
 			}
@@ -839,7 +843,7 @@ function responsive_get_posts_archive_link() {
 
 	// If we don't have a category match, but we have an all categories page, use that.
 	if ( ! $archive_link && $all_cats ) {
-			$archive_link = $all_cats;
+		$archive_link = $all_cats;
 	}
 
 	if ( ! $archive_link ) {


### PR DESCRIPTION
Fixes warnings when `responsive_get_posts_archive_link()` is called on a main query page that doesn't have and Categories assigned to it.

To see the problem, call the function on a regular page, activate query monitor, then hover over the admin toolbar for Query Monitor and click on "Warnings".

- Problem page: http://nm.cms-devl.bu.edu/r-cas-companion/#qm-php_errors
- Fixed page: http://milliktr.cms-devl.bu.edu/r-cas-companion/#qm-php_errors

## Summary

Two warnings were being thrown on this function, if it was called on a page that didn’t have any category terms assigned to it.

- `Invalid argument supplied for foreach()`: due to wp_list_pluck() usage at wp-content/themes/responsive-framework-2-x/inc/template-tags.php:804
- `in_array() expects parameter 2 to be array, boolean given`: due to in_array() usage at wp-content/themes/responsive-framework-2-x/inc/template-tags.php:817

![screen shot 2019-03-05 at 11 48 00 am](https://user-images.githubusercontent.com/26465346/53822016-e12e3400-3f3c-11e9-9bb1-2565c1d35604.png)

This fix sets $post_cat_ids to an empty array to resolve the second warning. And then it fills the array if it has terms to pluck term IDs from to resolve the first warning.

### Changes proposed in this pull request
- Validate categories exist before calling `wp_list_pluck()` on them.
- Validate pages exist before iterating through them.
- Minor PHPCS fixes and additional inline documentation.

### Review checklist

- [x] I've reviewed the [contribution guidelines](https://github.com/bu-ist/coding-standards/blob/develop/CONTRIBUTING.md).
- [x] I've updated `CHANGELOG.MD` with a brief explanation of the changes in this pull request in the unreleased section.
- [x] My code follows [BU Coding Standards](https://github.com/bu-ist/coding-standards).
