### PR TITLE
Fix customizer JS bugs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Replicated the `responsive_primary_nav_before` and `responsive_primary_nav_after` hooks into the BU version of `responsive_primary_nav`
+- Fixes #170
 
 ## 2.3.4
 

--- a/admin/theme-customizer.js
+++ b/admin/theme-customizer.js
@@ -24,17 +24,29 @@
 
 	// Manage the sidebar & layout controls. If left layout, then left sidebar is disabled and switched to right
 	$( document ).ready( function () {
-		$( '#burf_setting_layout input[type="radio"]' ).on( 'change', function() {
-			if( $( '#burf_setting_layout_side-nav').is( ':checked' ) ){
-				if( $( '#customize-control-burf_setting_sidebar_location input[value="left"]' ).is( ':checked' ) ){
-					$( '#customize-control-burf_setting_sidebar_location input[value="left"]' ).attr( 'checked', false ).attr( 'disabled', 'disabled' );
-					$( '#customize-control-burf_setting_sidebar_location input[value="right"]' ).attr( 'checked', true ).change();
-				}
-			}else {
-				$( '#customize-control-burf_setting_sidebar_location input[value="left"]' ).attr( 'checked', false ).attr( 'disabled', false );
-			}
 
-		} );
+		function preventBadLayoutDecisions() {
+			var $sidebarLocationLeft = $( '#customize-control-burf_setting_sidebar_location input[value="left"]' ),
+			$sidebarLocationRight = $( '#customize-control-burf_setting_sidebar_location input[value="right"]' );
+
+			if ( $( '#burf_setting_layout_side-nav' ).is( ':checked' ) ) {
+				if( $sidebarLocationLeft.is( ':checked' ) ) {
+					// Uncheck and disable the left sidebar option
+					$sidebarLocationLeft.attr( 'checked', false ).attr( 'disabled', 'disabled' );
+
+					// Check the right sidebar instead
+					$sidebarLocationRight.attr( 'checked', true ).change();
+				}
+			} else {
+				// Leave it alone, but reinstate the ability to change it
+				$sidebarLocationLeft.attr( 'disabled', false );
+			}
+		}
+
+		$( '#burf_setting_layout input[type="radio"]' ).on( 'change', preventBadLayoutDecisions );
+
+		// Run the bad decisions layout check on initial load as well
+		preventBadLayoutDecisions();
 	} );
 
 } ) ( wp.customize, jQuery );

--- a/admin/theme-customizer.js
+++ b/admin/theme-customizer.js
@@ -6,68 +6,6 @@
  */
 
 ( function( api, $ ) {
-	var cssTemplate = wp.template( 'responsive-framework-color-scheme' ),
-		colorSchemes = responsiveColor.schemes,
-		colorRegions = _.keys( responsiveColor.regions ),
-		optionalRegions = responsiveColor.optional;
-
-	api.controlConstructor.select = api.Control.extend( {
-		ready: function() {
-			if ( 'burf_setting_color_scheme' === this.id ) {
-				this.setting.bind( 'change', function( value ) {
-
-					// Update color pickers when new scheme is selected
-					_.each( colorRegions, function ( setting, index ) {
-						api( 'burf_setting_custom_colors[' + setting + ']' ).set( colorSchemes[ value ].colors[ index ] );
-						api.control( 'burf_setting_custom_colors[' + setting + ']' ).container.find( '.color-picker-hex' )
-							.data( 'data-default-color', colorSchemes[ value ].colors[ index ] )
-							.wpColorPicker( 'defaultColor', colorSchemes[ value ].colors[ index ] );
-					});
-
-					// Reset active region toggles
-					_.each( colorSchemes[value].active, function ( value, key ) {
-						api( 'burf_setting_active_color_regions[' + key + ']' ).set( value );
-					} );
-				} );
-			}
-		}
-	} );
-
-	// Generate the CSS for the current Color Scheme.
-	function updateCSS() {
-		var scheme = api( 'burf_setting_color_scheme' )(), css,
-			colors = _.object( colorRegions, colorSchemes[ scheme ].colors );
-
-		// Merge in color scheme overrides.
-		_.each( colorRegions, function( setting ) {
-			colors[ setting ] = api( 'burf_setting_custom_colors[' + setting + ']' )();
-		});
-
-		// Merge in optional region states for template conditionals
-		colors.active = {};
-		_.each( _.keys( colorSchemes[scheme].active ), function ( setting ) {
-			colors.active[ setting ] = api( 'burf_setting_active_color_regions[' + setting + ']' )();
-		} );
-
-		css = cssTemplate( colors );
-
-		api.previewer.send( 'update-color-scheme-css', css );
-	}
-
-	// Update the CSS whenever a color setting is changed.
-	_.each( colorRegions, function( setting ) {
-		api( 'burf_setting_custom_colors[' + setting + ']', function( setting ) {
-			// TODO: Toggle visibility of associated color picker
-			setting.bind( updateCSS );
-		} );
-	} );
-
-	// Update the CSS whenever an optional region checkbox is toggled.
-	_.each( optionalRegions, function ( region ) {
-		api( 'burf_setting_active_color_regions[' + region + ']', function( setting ) {
-			setting.bind( updateCSS );
-		} );
-	} );
 
 	// Sync checkbox group values to hidden setting checkbox
 	$( document ).ready( function () {


### PR DESCRIPTION
Fixes #170 .

See fixes in action here: http://bun.cms-devl.bu.edu/responsi/wp-admin/customize.php?url=http%3A%2F%2Fbun.cms-devl.bu.edu%2Fresponsi%2F

You should be able to select Alternate Footbar and publish now. Also, when you select the left layout, the left sidebar should be disabled, even on page load.

### Changes proposed in this pull request
- Remove color picker JS
- Check layout logic on load as well as on layout change

### Review checklist

- [x] I've reviewed the [contribution guidelines](https://github.com/bu-ist/coding-standards/blob/develop/CONTRIBUTING.md).
- [x] I've updated `CHANGELOG.MD` with a brief explanation of the changes in this pull request in the unreleased section.
- [x] My code follows [BU Coding Standards](https://github.com/bu-ist/coding-standards).
