### PR TITLE
Phil/calendar adjustments

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 # Changelog
 
+## Unreleased
+
+- Add `rel="nofollow"` attributes to event links in the calendar widget output.
+- Replace the template name in `calendar-single.php` with a note about its
+  usage.
+
 ## 2.3.5
 
 - Replicated the `responsive_primary_nav_before` and `responsive_primary_nav_after` hooks into the BU version of `responsive_primary_nav`

--- a/inc/calendar.php
+++ b/inc/calendar.php
@@ -187,7 +187,7 @@ function responsive_calendar_format_default( $events, $base_url, $calendar_id = 
 			$output .= sprintf( '
 				<li class="widget-calendar-event widget-calendar-event-default">
 					<time class="widget-calendar-date widget-calendar-date-default">%s</time>
-					<a href="%s" class="widget-calendar-title widget-calendar-title-default widget-calendar-link widget-calendar-link-default">%s</a>
+					<a href="%s" class="widget-calendar-title widget-calendar-title-default widget-calendar-link widget-calendar-link-default" rel="no-follow">%s</a>
 				</li>', date( 'n.j', $event['starts'] ), esc_url( $url ), $event['summary'] );
 
 			$output .= "\n";
@@ -217,7 +217,7 @@ function responsive_calendar_format_fulldate( $events, $base_url, $calendar_id =
 			$output .= sprintf( '
 				<li class="widget-calendar-event widget-calendar-event-fulldate">
 					<time class="widget-calendar-date widget-calendar-date-fulldate">%s</time>
-					<a href="%s" class="widget-calendar-title widget-calendar-title-fulldate widget-calendar-link widget-calendar-link-fulldate">%s</a>
+					<a href="%s" class="widget-calendar-title widget-calendar-title-fulldate widget-calendar-link widget-calendar-link-fulldate" rel="no-follow">%s</a>
 				</li>', date( 'l, F j', $event['starts'] ), esc_url( $url ), $event['summary'] );
 
 			$output .= "\n";
@@ -246,7 +246,7 @@ function responsive_calendar_format_graphic( $events, $base_url, $calendar_id = 
 
 			$output .= sprintf( '
 				<li class="widget-calendar-event widget-calendar-event-graphic">
-					<a href="%s" class="widget-calendar-link widget-calendar-link-graphic">
+					<a href="%s" class="widget-calendar-link widget-calendar-link-graphic" rel="no-follow">
 						<time class="widget-calendar-date widget-calendar-date-graphic">
 							<span class="widget-calendar-day widget-calendar-day-graphic">%s</span>
 							<span class="widget-calendar-month widget-calendar-month-graphic">%s</span>

--- a/page-templates/calendar-single.php
+++ b/page-templates/calendar-single.php
@@ -1,6 +1,10 @@
 <?php
 /**
- * Template Name: Calendar
+ * Template used for individual event views.
+ *
+ * This is not a selectable page template - its use is determined by query
+ * parameters via the `responsive_calendar_template_include` function in
+ * `inc/template-hooks.php`.
  *
  * @package Responsive_Framework
  */


### PR DESCRIPTION
Makes changes based on the recommendations outlined in https://trello.com/c/WcDWLbpV/8-ca-32-bu-calendar-widget-caching.

### Changes proposed in this pull request
- Per recommendations in the performance audit, adds `rel="nofollow"` attributes to event links in the calendar widget output.
- Replaces the template name in `calendar-single.php` with a note about its usage.

### Review checklist

- [x] I've reviewed the [contribution guidelines](https://github.com/bu-ist/coding-standards/blob/develop/CONTRIBUTING.md).
- [x] I've updated `CHANGELOG.MD` with a brief explanation of the changes in this pull request in the unreleased section.
- [x] My code follows [BU Coding Standards](https://github.com/bu-ist/coding-standards).
