### PR TITLE
Add pagination to search template

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## Unreleased
+- Added pagination to search template.
+
 ## 2.3.5
 
 - Replicated the `responsive_primary_nav_before` and `responsive_primary_nav_after` hooks into the BU version of `responsive_primary_nav`

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -633,6 +633,8 @@ function responsive_posts_navigation( $args = array(), WP_Query $query = null ) 
 			if ( ! empty( $post_type ) ) {
 				$archive_type = $post_type->labels->singular_name;
 			}
+		} elseif ( is_search() ) {
+			$archive_type = 'search';
 		}
 
 		$defaults = array(

--- a/search.php
+++ b/search.php
@@ -35,6 +35,8 @@ get_header(); ?>
 
 			<?php endwhile; ?>
 
+			<?php responsive_posts_navigation(); ?>
+
 		<?php else : ?>
 
 			<?php get_template_part( 'template-parts/no-content', 'search' ); ?>


### PR DESCRIPTION
The WP search template did not have pagination, so if used it would only show the latest x posts (based on the site’s default setting for posts_per_page).

This commit adds the pagination back in utilizing the template tag already available in responsi for outputting a current query’s pagination.

Also added a conditional to the pagination function to change the $archive_type to ‘search’ to avoid seeing ‘Older’ and ‘Newer’ in the pagination, and instead use the default which is ‘Previous’ and ‘Next’.

### Review checklist

- [x] I've reviewed the [contribution guidelines](https://github.com/bu-ist/coding-standards/blob/develop/CONTRIBUTING.md).
- [x] I've updated `CHANGELOG.MD` with a brief explanation of the changes in this pull request in the unreleased section.
- [x] My code follows [BU Coding Standards](https://github.com/bu-ist/coding-standards).
