### PR TITLE
Fix broken Travis CI tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
-language: php
-
 sudo: false
+dist: trusty
+
+language: php
 
 notifications:
   slack:
@@ -10,35 +11,28 @@ notifications:
     on_success: always
 
   email:
-    on_success: change
+    on_success: never
     on_failure: change
 
-env:
-  global:
-    - WP_TRAVISCI=travis:phpunit
-
-matrix:
-  fast_finish: true
-  include:
-    - php: 7.0
-      env: WP_VERSION=trunk
-    - php: 7.0
-      env: WP_VERSION=latest
-    - php: 7.0
-      env: WP_VERSION=4.9.7
-    - php: 7.1
-      env: WP_VERSION=trunk
-    - php: 7.1
-      env: WP_VERSION=latest
-    - php: 7.2
-      env: WP_VERION=trunk
-    - php: 7.2
-      env: WP_VERION=latest
+branches:
+  only:
+  - /.*/
 
 cache:
-  apt: true
   directories:
-    - "$HOME/.composer/cache"
+    - vendor
+    - $HOME/.composer/cache
+
+matrix:
+  include:
+    - php: 7.2
+      env: WP_VERSION=latest
+    - php: 7.2
+      env: WP_VERSION=4.9.10
+    - php: 7.0
+      env: WP_VERSION=latest
+    - php: 7.0
+      env: WP_VERSION=4.9.10
 
 before_install:
   - composer self-update
@@ -52,15 +46,22 @@ before_script:
       ./cc-test-reporter before-build
     fi
 
-  - export PATH="$HOME/.composer/vendor/bin:$PATH"
+   - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - |
-    if [[ "$WP_TRAVISCI" == "travis:phpunit" ]]; then
-      if [[ ${TRAVIS_PHP_VERSION:0:2} == "7." ]]; then
-        composer global require "phpunit/phpunit=5.7.*"
-      else
-        composer global require "phpunit/phpunit=4.8.*"
-      fi
+    if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then
+      phpenv config-rm xdebug.ini
+    else
+      echo "xdebug.ini does not exist"
+    fi
+  - |
+    if [[ ! -z "$WP_VERSION" ]] ; then
       bash bin/install-wp-tests.sh wordpress_test root '' localhost $WP_VERSION
+      composer global require "phpunit/phpunit=4.8.*|5.7.*"
+    fi
+  - |
+    if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
+      composer global require wp-coding-standards/wpcs
+      phpcs --config-set installed_paths $HOME/.composer/vendor/wp-coding-standards/wpcs
     fi
 
 script:
@@ -73,6 +74,11 @@ script:
       phpunit
       WP_MULTISITE=1 phpunit
     fi
+  - |
+    if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
+      phpcs
+    fi
+
 
 after_script:
   - |

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,10 @@ notifications:
     on_success: never
     on_failure: change
 
+env:
+  global:
+    - WP_TRAVISCI=travis:phpunit
+
 branches:
   only:
   - /.*/
@@ -24,6 +28,7 @@ cache:
     - $HOME/.composer/cache
 
 matrix:
+  fast_finish: true
   include:
     - php: 7.2
       env: WP_VERSION=latest

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,7 +46,7 @@ before_script:
       ./cc-test-reporter before-build
     fi
 
-   - export PATH="$HOME/.composer/vendor/bin:$PATH"
+  - export PATH="$HOME/.composer/vendor/bin:$PATH"
   - |
     if [ -f ~/.phpenv/versions/$(phpenv version-name)/etc/conf.d/xdebug.ini ]; then
       phpenv config-rm xdebug.ini
@@ -78,7 +78,6 @@ script:
     if [[ "$WP_TRAVISCI" == "phpcs" ]] ; then
       phpcs
     fi
-
 
 after_script:
   - |

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixes broken Travis CI tests.
+
 ## 2.3.5
 
 - Replicated the `responsive_primary_nav_before` and `responsive_primary_nav_after` hooks into the BU version of `responsive_primary_nav`

--- a/bin/install-wp-tests.sh
+++ b/bin/install-wp-tests.sh
@@ -13,6 +13,7 @@ WP_VERSION=${5-latest}
 SKIP_DB_CREATE=${6-false}
 
 TMPDIR=${TMPDIR-/tmp}
+TMPDIR=$(echo $TMPDIR | sed -e "s/\/$//")
 WP_TESTS_DIR=${WP_TESTS_DIR-$TMPDIR/wordpress-tests-lib}
 WP_CORE_DIR=${WP_CORE_DIR-$TMPDIR/wordpress/}
 


### PR DESCRIPTION
:construction_worker: Travis tests were failing, this PR attempts to resolve them.

Uses most of the config from `bu-custom-roles` since that was the latest repo we fixed Travis CI tests on.

Updates the matrix to use 4.9.10 and latest PHP 7.2 versions as well as 7.0

### Review checklist

- [x] I've reviewed the [contribution guidelines](https://github.com/bu-ist/coding-standards/blob/develop/CONTRIBUTING.md).
- [x] I've updated `CHANGELOG.MD` with a brief explanation of the changes in this pull request in the unreleased section.
- [x] My code follows [BU Coding Standards](https://github.com/bu-ist/coding-standards).
