### PR TITLE
add responsive_html_class() function and filter hook

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## Unreleased
 
 - Removes duplicate call to burf-base, which is a dependency of burf-theme.
+- Add responsive_html_class() for use on the `<html>` tag for class name output/filtering.
 
 ## 2.3.61
 

--- a/functions.php
+++ b/functions.php
@@ -559,7 +559,7 @@ function r_is_narrow_template() {
  * @since 2.3.61
  *
  * @param string|array $class One or more classes to add to the class list.
- * @param boolean $tag Output classes with 'class' attribute
+ * @param boolean $attribute Output classes with 'class' attribute.
  */
 function responsive_html_class( $class = '', $attribute = true ) {
 	$classes = array();
@@ -581,7 +581,7 @@ function responsive_html_class( $class = '', $attribute = true ) {
 		return;
 	}
 
-	if ( $attribute === true ) {
+	if ( true === $attribute ) {
 		// Separates classes with a single space, collates classes for the HTML element.
 		echo 'class="' . join( ' ', array_map( 'esc_attr', array_unique( $classes ) ) ) . '"';
 	} else {

--- a/functions.php
+++ b/functions.php
@@ -554,6 +554,44 @@ function r_is_narrow_template() {
 }
 
 /**
+ * Displays the classes for the HTML tag.
+ *
+ * @since 2.3.61
+ *
+ * @param string|array $class One or more classes to add to the class list.
+ * @param boolean $tag Output classes with 'class' attribute
+ */
+function responsive_html_class( $class = '', $attribute = true ) {
+	$classes = array();
+
+	$class   = r_prepare_passed_classes( $class );
+	$classes = array_merge( $classes, array_map( 'esc_attr', $class ) );
+
+	/**
+	 * Filters the list of CSS classes for the HTML tag.
+	 *
+	 * @since 2.3.61
+	 *
+	 * @param array $classes HTML element classes.
+	 * @param array $class   Additional classes added to the HTML element.
+	 */
+	$classes = apply_filters( 'r_html_class', $classes, $class );
+
+	if ( empty( $classes ) ) {
+		return;
+	}
+
+	if ( $attribute === true ) {
+		// Separates classes with a single space, collates classes for the HTML element.
+		echo 'class="' . join( ' ', array_map( 'esc_attr', array_unique( $classes ) ) ) . '"';
+	} else {
+		// Separates classes with a single space, collates classes for the HTML element
+		// without the class attribute name.
+		echo join( ' ', array_map( 'esc_attr', array_unique( $classes ) ) ) . ' ';
+	}
+}
+
+/**
  * Displays the classes for the inner content container.
  *
  * @since 2.0.0

--- a/functions.php
+++ b/functions.php
@@ -559,7 +559,7 @@ function r_is_narrow_template() {
  * @since 2.3.61
  *
  * @param string|array $class One or more classes to add to the class list.
- * @param boolean $attribute Output classes with 'class' attribute.
+ * @param boolean      $attribute Output classes with 'class' attribute.
  */
 function responsive_html_class( $class = '', $attribute = true ) {
 	$classes = array();

--- a/header.php
+++ b/header.php
@@ -7,11 +7,11 @@
 
 ?>
 <!DOCTYPE html>
-<!--[if lt IE 7]>     <html class="no-js ie lt-ie9 lt-ie8 lt-ie7"  lang="en"> <![endif]-->
-<!--[if IE 7]>        <html class="no-js ie lt-ie9 lt-ie8"  lang="en"> <![endif]-->
-<!--[if IE 8]>        <html class="no-js ie lt-ie9"  lang="en"> <![endif]-->
-<!--[if IE 9]>        <html class="no-js ie ie9"  lang="en"> <![endif]-->
-<!--[if gt IE 9]><!--><html class="no-js"  lang="en"><!--<![endif]-->
+<!--[if lt IE 7]>     <html <?php responsive_html_class( 'no-js ie lt-ie9 lt-ie8 lt-ie7' ); ?>  lang="en"> <![endif]-->
+<!--[if IE 7]>        <html <?php responsive_html_class( 'no-js ie lt-ie9 lt-ie8' ); ?>  lang="en"> <![endif]-->
+<!--[if IE 8]>        <html <?php responsive_html_class( 'no-js ie lt-ie9' ); ?>  lang="en"> <![endif]-->
+<!--[if IE 9]>        <html <?php responsive_html_class( 'no-js ie ie9' ); ?>  lang="en"> <![endif]-->
+<!--[if gt IE 9]><!--><html <?php responsive_html_class( 'no-js' ); ?>  lang="en"><!--<![endif]-->
 <head>
 	<title><?php responsive_get_title(); ?></title>
 	<meta charset="<?php bloginfo( 'charset' ); ?>" />


### PR DESCRIPTION
### Changes proposed in this pull request
- adds `responsive_html_class()` function
- uses new function in `header.php` template on the `<html>` tag for classes output

This new function will let themes easily add a class to the HTML tag. For instance if a template or component needs a class name on the HTML tag in addition to the body tag for styling purposes.

This is needed to better support the Sequential Cards Gutenberg Block in BU Prepress and avoid using JS to add the class to the `<html>` tag on posts with the block present.

### Required pull requests to merge (usually a pull request on Foundation or a plugin)

- none, I think.

### Review checklist

- [x] I've reviewed the [contribution guidelines](https://github.com/bu-ist/coding-standards/blob/develop/CONTRIBUTING.md).
- [x] I've updated `CHANGELOG.MD` with a brief explanation of the changes in this pull request in the unreleased section.
- [x] My code follows [BU Coding Standards](https://github.com/bu-ist/coding-standards).
