### PR TITLE
Move location of the skip link

### DIFF
--- a/header.php
+++ b/header.php
@@ -39,6 +39,7 @@
 </head>
 
 <body id="top" <?php body_class(); ?>>
+	<a class="skip-link" href="#main">Skip to Main Content</a>
 	<?php
 		/**
 		 * Fires immediately after the opening body tag.
@@ -58,7 +59,6 @@
 	?>
 	<header class="masthead" role="banner">
 		<div class="masthead-container">
-				<a class="skip-link" href="#main">Skip to Main Content</a>
 			<?php get_template_part( 'template-parts/masthead', responsive_layout() ); ?>
 		</div>
 	</header>


### PR DESCRIPTION
Fixes #245 

### Changes proposed in this pull request

- Move the location of the skip link to directly underneath the opening body tag to avoid placement conflicts.

### Test sites

Clone these sites to your sandbox, and review them briefly. Does everything work as expected?

- [ ] **Kitchen Sink Site** http://10up-responsi.cms-devl.bu.edu/kitchensink/
- [ ] **BU Landing Pages** http://10up-responsi.cms-devl.bu.edu/bu-landing-pages/
- [ ] **BU Banners** http://10up-responsi.cms-devl.bu.edu/bu-banners/
- [ ] **Faculty Model Site (color palettes)** http://10up-responsi.cms-devl.bu.edu/facultymodel/
- [ ] **BU Bands (light custom CSS)** http://10up-responsi.cms-devl.bu.edu/bands/
- [ ] **Data Sciences (complex custom CSS)** http://10up-responsi.cms-devl.bu.edu/cds-faculty/
- [ ] **Provost Advising (child theme)** http://10up-responsi.cms-devl.bu.edu/advising/

### Review checklist

- [x] I have tested my changes in my sandbox on Responsive Framework and at least one child theme.
- [x] I have tested any new filters or action hooks I have introduced in a child theme to ensure they work correctly.
- [x] I've reviewed the [contribution guidelines](https://github.com/bu-ist/coding-standards/blob/develop/CONTRIBUTING.md).
- [x] I've updated `CHANGELOG.MD` with a brief explanation of the changes in this pull request in the unreleased section.
- [x] My code follows [BU Coding Standards](https://github.com/bu-ist/coding-standards).
