### PR TITLE
Feature/61 limit utility nav

### DIFF
--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -1211,3 +1211,49 @@ function responsive_get_the_excerpt( $post_id = null, $length = 55 ) {
 	}
 	return $excerpt;
 }
+
+
+/**
+ * Limit the children output from the utility menu to three.
+ *
+ * @param string   $items The HTML list content for the menu items.
+ * @param stdClass $args  An object containing wp_nav_menu() arguments.
+ * @return string The HTML Menu items.
+ */
+function limit_utility_nav_menu_items( $items, $args ) {
+
+	// Build XML document for processing.
+	$items = "<root>$items</root>";
+	$dom   = new DOMDocument();
+	$dom->loadXML( $items );
+	$doc      = $dom->documentElement;
+	$submenus = $doc->getElementsByTagName( 'ul' );
+
+	$nodes_to_remove = array();
+
+	// Find nodes to remove.
+	foreach ( $submenus as $key => $submenu ) {
+		$lis      = $submenu->getElementsByTagName( 'li' );
+		$li_count = $lis->length;
+
+		// Allow maximum of 3 children per submenu.
+		// Adapt counter for zero indexing of DOM document.
+		if ( 3 < $li_count ) {
+			for ( $i = $li_count - 1; $i > 2; $i-- ) {
+				$node = $lis->item( $i );
+				array_push( $nodes_to_remove, $node );
+			}
+		}
+	}
+
+	// Remove Nodes.
+	foreach ( $nodes_to_remove as $node ) {
+		$node->parentNode->removeChild( $node );
+	}
+
+	// Prepare Return Values.
+	$items = $dom->saveXML();
+	$items = str_replace( array( '<root>', '</root>' ), '', $items );
+	return $items;
+}
+add_filter( 'wp_nav_menu_items', 'limit_utility_nav_menu_items', 10, 2 );

--- a/inc/template-tags.php
+++ b/inc/template-tags.php
@@ -434,6 +434,7 @@ if ( ! function_exists( 'responsive_get_utility_nav' ) ) {
 					'menu_class'     => 'utility-nav-menu',
 					'container'      => false,
 					'echo'           => false,
+					'depth'          => 2,
 				)
 			);
 		}


### PR DESCRIPTION
Fixes #61 .

### Changes proposed in this pull request

- Limit the output hierarchy depth to 2 items( parent and 1 below ) 

- Limit the number of items to output for each possible submenu to 3

-

### Required pull requests to merge (usually a pull request on Foundation or a plugin)

-

-

### Test sites

Clone these sites to your sandbox, and review them briefly. Does everything work as expected?

- [ ] **Kitchen Sink Site** http://10up-responsi.cms-devl.bu.edu/kitchensink/
- [ ] **BU Landing Pages** http://10up-responsi.cms-devl.bu.edu/bu-landing-pages/
- [ ] **BU Banners** http://10up-responsi.cms-devl.bu.edu/bu-banners/
- [ ] **Faculty Model Site (color palettes)** http://10up-responsi.cms-devl.bu.edu/facultymodel/
- [ ] **BU Bands (light custom CSS)** http://10up-responsi.cms-devl.bu.edu/bands/
- [ ] **Data Sciences (complex custom CSS)** http://10up-responsi.cms-devl.bu.edu/cds-faculty/
- [ ] **Provost Advising (child theme)** http://10up-responsi.cms-devl.bu.edu/advising/

### Review checklist

- [ ] I have tested my changes in my sandbox on Responsive Framework and at least one child theme.
- [ ] I have tested any new filters or action hooks I have introduced in a child theme to ensure they work correctly.
- [ ] I've reviewed the [contribution guidelines](https://github.com/bu-ist/coding-standards/blob/develop/CONTRIBUTING.md).
- [ ] I've updated `CHANGELOG.MD` with a brief explanation of the changes in this pull request in the unreleased section.
- [ ] My code follows [BU Coding Standards](https://github.com/bu-ist/coding-standards).
