### PR TITLE
Updated default plugins when creating new site

### DIFF
--- a/bu-site-init.php
+++ b/bu-site-init.php
@@ -187,6 +187,10 @@ function responsive_initialize_site( $site, $site_id, $admin_id, $domain, $path,
 		'bu-post-details/bu-post-details.php',
 		'link-lists/link-lists.php',
 		'bu-sharing/bu-sharing.php',
+		'cmb2/init.php',
+		'bu-landing-pages/bu-landing-pages.php',
+		'bu-text-widget/bu-text-widget.php',
+		'classic-editor/classic-editor.php',
 	) );
 
 	// Default comment depth.


### PR DESCRIPTION
Fixes #{issue-number}.

### Changes proposed in this pull request

- Default plugins activated when creating new site. 

### Required pull requests to merge (usually a pull request on Foundation or a plugin)

- 

-

### Test sites

Clone these sites to your sandbox, and review them briefly. Does everything work as expected?

- [x] **Kitchen Sink Site** http://10up-responsi.cms-devl.bu.edu/kitchensink/
- [x] **BU Landing Pages** http://10up-responsi.cms-devl.bu.edu/bu-landing-pages/
- [x] **BU Banners** http://10up-responsi.cms-devl.bu.edu/bu-banners/
- [x] **Faculty Model Site (color palettes)** http://10up-responsi.cms-devl.bu.edu/facultymodel/
- [x] **BU Bands (light custom CSS)** http://10up-responsi.cms-devl.bu.edu/bands/
- [x] **Data Sciences (complex custom CSS)** http://10up-responsi.cms-devl.bu.edu/cds-faculty/
- [x] **Provost Advising (child theme)** http://10up-responsi.cms-devl.bu.edu/advising/

### Review checklist

- [x] I have tested my changes in my sandbox on Responsive Framework and at least one child theme.
- [x] I have tested any new filters or action hooks I have introduced in a child theme to ensure they work correctly.
- [x] I've reviewed the [contribution guidelines](https://github.com/bu-ist/coding-standards/blob/develop/CONTRIBUTING.md).
- [] I've updated `CHANGELOG.MD` with a brief explanation of the changes in this pull request in the unreleased section.
- [x] My code follows [BU Coding Standards](https://github.com/bu-ist/coding-standards).
