### PR TITLE
Replaced css injection with links to stylesheets

### DIFF
--- a/admin/theme-customizer.php
+++ b/admin/theme-customizer.php
@@ -349,7 +349,7 @@ function responsive_customizer_styles() {
 		$use_cache = false;
 	}
 
-	echo responsive_get_customizer_styles( $use_cache ); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
+	echo responsive_get_customizer_styles(); // phpcs:ignore WordPress.Security.EscapeOutput.OutputNotEscaped
 }
 
 if ( ! defined( 'RESPONSIVE_CUSTOMIZER_DISABLE' ) ) {

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -194,14 +194,14 @@ function responsive_get_customizer_styles( $use_cache = true ) {
 	$fonts_css = responsive_get_css( 'font' );
 	if ( $fonts_css ) {
 
-		$styles[] = sprintf( '<link rel="stylesheet" href="%s"/>', $fonts_css);
+		$styles[] = sprintf( '<link rel="stylesheet" href="%s"/>', $fonts_css );
 	}
 
 	// Colors.
 	$colors_css = responsive_get_css( 'color' );
 	if ( $colors_css ) {
-		
-		$styles[] = sprintf( '<link rel="stylesheet" href="%s"/>', $colors_css);
+
+		$styles[] = sprintf( '<link rel="stylesheet" href="%s"/>', $colors_css );
 	}
 
 	// Concatenate font and color styles.

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -173,34 +173,23 @@ function responsive_get_color_palette() {
 /**
  * Generate inline customizer style block.
  *
- * @param boolean $use_cache Whether to use styles cached in an option. Default is true.
  *
  * @return string $styles CSS Styles for use in the Customizer.
  */
-function responsive_get_customizer_styles( $use_cache = true ) {
+function responsive_get_customizer_styles() {
 
 	$styles              = array();
 	$is_script_debugging = defined( 'SCRIPT_DEBUG' ) && SCRIPT_DEBUG;
 
-	// Check cache first if requested and SCRIPT_DEBUG is off.
-	if ( $use_cache && ! $is_script_debugging ) {
-		$styles = get_option( 'burf_customizer_styles' );
-		if ( $styles ) {
-			return $styles;
-		}
-	}
-
 	// Fonts.
 	$fonts_css = responsive_get_css( 'font' );
 	if ( $fonts_css ) {
-
 		$styles[] = sprintf( '<link rel="stylesheet" href="%s"/>', $fonts_css );
 	}
 
 	// Colors.
 	$colors_css = responsive_get_css( 'color' );
 	if ( $colors_css ) {
-
 		$styles[] = sprintf( '<link rel="stylesheet" href="%s"/>', $colors_css );
 	}
 
@@ -208,7 +197,7 @@ function responsive_get_customizer_styles( $use_cache = true ) {
 	$styles = implode( PHP_EOL, $styles );
 
 	// Only cache minified styles when script debugging is disabled.
-	if ( $styles && $use_cache && ! $is_script_debugging ) {
+	if ( $styles && ! $is_script_debugging ) {
 		update_option( 'burf_customizer_styles', $styles );
 	}
 	return $styles;

--- a/inc/customizer.php
+++ b/inc/customizer.php
@@ -194,30 +194,14 @@ function responsive_get_customizer_styles( $use_cache = true ) {
 	$fonts_css = responsive_get_css( 'font' );
 	if ( $fonts_css ) {
 
-		// Minify font styles if SCRIPT_DEBUG is off.
-		if ( ! $is_script_debugging ) {
-			$csstidy = responsive_css_tidy();
-			$csstidy->parse( $fonts_css );
-			$fonts_css = $csstidy->print->plain();
-			unset( $csstidy );
-		}
-
-		$styles[] = sprintf( '<style type="text/css" id="responsive-customizer-fonts">%s</style>', $fonts_css );
+		$styles[] = sprintf( '<link rel="stylesheet" href="%s"/>', $fonts_css);
 	}
 
 	// Colors.
 	$colors_css = responsive_get_css( 'color' );
 	if ( $colors_css ) {
-
-		// Minify color styles if SCRIPT_DEBUG is off.
-		if ( ! $is_script_debugging ) {
-			$csstidy = responsive_css_tidy();
-			$csstidy->parse( $colors_css );
-			$colors_css = $csstidy->print->plain();
-			unset( $csstidy );
-		}
-
-		$styles[] = sprintf( '<style type="text/css" id="responsive-customizer-colors">%s</style>', $colors_css );
+		
+		$styles[] = sprintf( '<link rel="stylesheet" href="%s"/>', $colors_css);
 	}
 
 	// Concatenate font and color styles.
@@ -308,11 +292,7 @@ function responsive_get_css( $palette ) {
 	}
 
 	if ( ! empty( $get_palette ) ) {
-		$request = wp_remote_get( get_template_directory_uri() . '/css/' . $get_palette . '.css' );
-
-		if ( ! is_wp_error( $request ) && 200 === wp_remote_retrieve_response_code( $request ) ) {
-			$css = wp_remote_retrieve_body( $request );
-		}
+		$css = get_template_directory_uri() . '/css/' . $get_palette . '.css';
 	}
 
 	return $css;


### PR DESCRIPTION
Fixes INC3683185. 

### Changes proposed in this pull request
Removes requests that inject css into pages with fonts or colors set by the customizer. Replaced with direct links to the stylesheets. 


### Test sites
Tested on www-test:
https://www-test.bu.edu/responsiveframeworkv2/

Clone these sites to your sandbox, and review them briefly. Does everything work as expected?

- [x] **Kitchen Sink Site** http://10up-responsi.cms-devl.bu.edu/kitchensink/
- [x] **BU Landing Pages** http://10up-responsi.cms-devl.bu.edu/bu-landing-pages/
- [x] **BU Banners** http://10up-responsi.cms-devl.bu.edu/bu-banners/
- [x] **Faculty Model Site (color palettes)** http://10up-responsi.cms-devl.bu.edu/facultymodel/
- [x] **BU Bands (light custom CSS)** http://10up-responsi.cms-devl.bu.edu/bands/
- [x] **Data Sciences (complex custom CSS)** http://10up-responsi.cms-devl.bu.edu/cds-faculty/
- [x] **Provost Advising (child theme)** http://10up-responsi.cms-devl.bu.edu/advising/

### Review checklist

- [x] I have tested my changes in my sandbox on Responsive Framework and at least one child theme.
- [x] I have tested any new filters or action hooks I have introduced in a child theme to ensure they work correctly.
- [x] I've reviewed the [contribution guidelines](https://github.com/bu-ist/coding-standards/blob/develop/CONTRIBUTING.md).
- [x] I've updated `CHANGELOG.MD` with a brief explanation of the changes in this pull request in the unreleased section.
- [x] My code follows [BU Coding Standards](https://github.com/bu-ist/coding-standards).
